### PR TITLE
Bump to v1.3.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+  * Add support for money and smallmoney columns [#1](https://github.com/singer-io/tap-mssql/pull/1)
+
 ## 1.2.3
   * Fix the sql query generation for full table interruptible syncs with composite pks [#53](https://github.com/stitchdata/tap-mssql/pull/53)
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.2.3"
+  "1.3.0"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
Version bump associated with https://github.com/singer-io/tap-mssql/pull/1