### PR TITLE
Discover row count as bigint

### DIFF
--- a/src/tap_mssql/catalog.clj
+++ b/src/tap_mssql/catalog.clj
@@ -284,7 +284,7 @@
 
 (defn get-approximate-row-count
   [conn-map]
-  (let [sql-query (str  "SELECT tbl.name as table_name, SCHEMA_NAME(tbl.schema_id) as schema_name, CAST(p.rows AS int) as row_count "
+  (let [sql-query (str  "SELECT tbl.name as table_name, SCHEMA_NAME(tbl.schema_id) as schema_name, CAST(p.rows AS bigint) as row_count "
                     "FROM sys.tables AS tbl "
                     "INNER JOIN sys.indexes AS idx ON idx.object_id = tbl.object_id and idx.index_id < 2 "
                     "INNER JOIN sys.partitions AS p ON p.object_id=CAST(tbl.object_id AS int) "


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-902

According to [this documentation](https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-partitions-transact-sql?view=sql-server-ver15), the `rows` column in `sys.partitions` is a bigint, so the cast to `int` could fail on very large tables. This PR changes it to cast to `bigint`.

# QA steps
 - [x] automated tests passing
 - [X] manual qa steps passing (list below)
 
# Risks
Very low risk, since bigint is a superset of int.

# Rollback steps
 - revert this branch
