### PR TITLE
Fix/binary field schemas

### DIFF
--- a/bin/test-db
+++ b/bin/test-db
@@ -18,7 +18,7 @@ def start_container(name):
     proc = subprocess.run(START_COMMAND, shell=True)
     if proc.returncode != 0:
         sys.exit("Exited with code: {}, the docker process failed to start.".format(proc.returncode))
-    print("Process started successfully, connect on localhost port 1433")
+    print("Process started successfully, connect on localhost port {}".format(os.getenv('STITCH_TAP_MSSQL_TEST_DATABASE_PORT', 1433)))
 
 def stop_container(name):
     STOP_COMMAND = "sudo docker stop {0} && sudo docker rm {0}"

--- a/src/tap_mssql/catalog.clj
+++ b/src/tap_mssql/catalog.clj
@@ -163,10 +163,8 @@
                                                "maxLength" (:column_size column)}
                            "nvarchar"         {"type"      ["string"]
                                                "maxLength" (:column_size column)}
-                           "binary"           {"type"      ["string"]
-                                               "maxLength" (:column_size column)}
-                           "varbinary"        {"type"      ["string"]
-                                               "maxLength" (:column_size column)}
+                           "binary"           {"type"      ["string"]}
+                           "varbinary"        {"type"      ["string"]}
                            "uniqueidentifier" {"type"    ["string"]
                                                ;; a string constant in the form
                                                ;; xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, in which

--- a/test/tap_mssql/discover_populated_catalog_datatyping_test.clj
+++ b/test/tap_mssql/discover_populated_catalog_datatyping_test.clj
@@ -344,28 +344,24 @@
                  ["streams" "datatyping_dbo_character_strings" "schema" "properties" "varchar_max"]))))
 
 (deftest ^:integration verify-binary-strings
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  ;; NB: Because we convert binary strings to hex, max_length is not accurate from the DB
+  ;; - Thus, it should not be included in the schemas
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_binary_strings" "schema" "properties" "binary"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_binary_strings" "schema" "properties" "binary_one"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 10}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_binary_strings" "schema" "properties" "binary_10"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_binary_strings" "schema" "properties" "varbinary"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_binary_strings" "schema" "properties" "varbinary_one"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 2147483647}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_binary_strings" "schema" "properties" "varbinary_max"]))))
 


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-910

We are converting binary fields to strings that have a length double + 2 of the actual length reported by MSSQL. For example, a `binary(4)` is 4 bytes wide, which in hex translates to `0xF0F0F0F0`, which is 10 characters long. This fails validation, since the `maxLength` on the generated schema is set to the MSSQL value of 4.

This PR removes the maxLength from these data types, since they aren't providing much value beyond rejection, and it's cleaner than arbitrary arithmetic that's bound to the specific transformation that we currently have.

# QA steps
 - [ ] automated tests passing
   - Updated datatyping discovery tests to reflect this change
 - [ ] manual qa steps passing (list below)
   - None performed
 
# Risks
Low, this makes the schema more permissive, rather than less.

# Rollback steps
 - revert this branch
