### PR TITLE
Improve Test Safety

### DIFF
--- a/test/tap_mssql/core_sync_test.clj
+++ b/test/tap_mssql/core_sync_test.clj
@@ -2,7 +2,8 @@
   (:require [tap-mssql.config :as config]
             [clojure.test :refer [is deftest]]
             [clojure.java.jdbc :as jdbc]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]]
@@ -14,18 +15,6 @@
             [tap-mssql.singer.messages :as singer-messages]
             [tap-mssql.config :as config])
   (:import [java.sql Date]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  [config]
-  (let [destroy-database-commands (->> (catalog/get-databases config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   [config]

--- a/test/tap_mssql/discover_config_test.clj
+++ b/test/tap_mssql/discover_config_test.clj
@@ -8,20 +8,9 @@
             [tap-mssql.catalog :as catalog]
             [tap-mssql.config :as config]
             [tap-mssql.singer.parse :as singer-parse]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  []
-  (let [destroy-database-commands (->> (catalog/get-databases test-db-config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map test-db-config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   []

--- a/test/tap_mssql/discover_empty_catalog_test.clj
+++ b/test/tap_mssql/discover_empty_catalog_test.clj
@@ -7,22 +7,11 @@
             [tap-mssql.core :refer :all]
             [tap-mssql.catalog :as catalog]
             [tap-mssql.config :as config]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  [config]
-  (let [destroy-database-commands (->> (catalog/get-databases config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   [config]

--- a/test/tap_mssql/discover_populated_catalog_datatyping_test.clj
+++ b/test/tap_mssql/discover_populated_catalog_datatyping_test.clj
@@ -8,20 +8,9 @@
             [clojure.set :as set]
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  []
-  (let [destroy-database-commands (->> (catalog/get-databases test-db-config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map test-db-config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   []

--- a/test/tap_mssql/discover_populated_catalog_metadata_test.clj
+++ b/test/tap_mssql/discover_populated_catalog_metadata_test.clj
@@ -8,20 +8,9 @@
             [clojure.set :as set]
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  []
-  (let [destroy-database-commands (->> (catalog/get-databases test-db-config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map test-db-config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   []

--- a/test/tap_mssql/discover_populated_catalog_test.clj
+++ b/test/tap_mssql/discover_populated_catalog_test.clj
@@ -7,20 +7,9 @@
             [clojure.set :as set]
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  []
-  (let [destroy-database-commands (->> (catalog/get-databases test-db-config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map test-db-config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   []

--- a/test/tap_mssql/discover_populated_catalog_with_multiple_non_system_databases_test.clj
+++ b/test/tap_mssql/discover_populated_catalog_with_multiple_non_system_databases_test.clj
@@ -7,20 +7,9 @@
             [clojure.set :as set]
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  []
-  (let [destroy-database-commands (->> (catalog/get-databases test-db-config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map test-db-config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   []

--- a/test/tap_mssql/discover_sync_precision_test.clj
+++ b/test/tap_mssql/discover_sync_precision_test.clj
@@ -8,22 +8,11 @@
             [clojure.set :as set]
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  [config]
-  (let [destroy-database-commands (->> (catalog/get-databases config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   [config]

--- a/test/tap_mssql/discover_tables_in_schema_test.clj
+++ b/test/tap_mssql/discover_tables_in_schema_test.clj
@@ -7,21 +7,9 @@
             [clojure.set :as set]
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config]]))
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  []
-  (let [destroy-database-commands (->> (catalog/get-databases test-db-config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map test-db-config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
-
-
 (defn create-test-db
   []
   (let [db-spec (config/->conn-map test-db-config)]

--- a/test/tap_mssql/sync_full_table_test.clj
+++ b/test/tap_mssql/sync_full_table_test.clj
@@ -9,22 +9,11 @@
             [clojure.set :as set]
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  [config]
-  (let [destroy-database-commands (->> (catalog/get-databases config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   [config]

--- a/test/tap_mssql/sync_incremental_test.clj
+++ b/test/tap_mssql/sync_incremental_test.clj
@@ -7,22 +7,11 @@
             [clojure.data.json :as json]
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  [config]
-  (let [destroy-database-commands (->> (catalog/get-databases config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   [config]

--- a/test/tap_mssql/sync_interruptible_full_table_test.clj
+++ b/test/tap_mssql/sync_interruptible_full_table_test.clj
@@ -11,22 +11,11 @@
             [tap-mssql.core :refer :all]
             [tap-mssql.sync-strategies.full :as sync]
             [tap-mssql.singer.messages :as singer-messages]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  [config]
-  (let [destroy-database-commands (->> (catalog/get-databases config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   [config]

--- a/test/tap_mssql/sync_log_based_test.clj
+++ b/test/tap_mssql/sync_log_based_test.clj
@@ -11,22 +11,11 @@
             [clojure.string :as string]
             [tap-mssql.core :refer :all]
             [tap-mssql.sync-strategies.logical :as logical]
-            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+            [tap-mssql.test-utils :refer [maybe-destroy-test-db
+                                          with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]]))
-
-(defn get-destroy-database-command
-  [database]
-  (format "DROP DATABASE %s" (:table_cat database)))
-
-(defn maybe-destroy-test-db
-  [config]
-  (let [destroy-database-commands (->> (catalog/get-databases config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
 
 (defn create-test-db
   [config]

--- a/test/tap_mssql/test_utils.clj
+++ b/test/tap_mssql/test_utils.clj
@@ -57,14 +57,20 @@
                  "if this is a valid test host.")
             config))))
 
+(defn- get-destroy-database-command
+  [database]
+  (format "DROP DATABASE %s" (:table_cat database)))
+
 (defn maybe-destroy-test-db
-  []
-  (test-utils/ensure-is-test-db test-db-config)
-  (let [destroy-database-commands (->> (catalog/get-databases test-db-config)
-                                       (filter catalog/non-system-database?)
-                                       (map get-destroy-database-command))]
-    (let [db-spec (config/->conn-map test-db-config)]
-      (jdbc/db-do-commands db-spec destroy-database-commands))))
+  ([]
+   (maybe-destroy-test-db test-db-config))
+  ([config]
+   (ensure-is-test-db config)
+   (let [destroy-database-commands (->> (catalog/get-databases config)
+                                        (filter catalog/non-system-database?)
+                                        (map get-destroy-database-command))]
+     (let [db-spec (config/->conn-map config)]
+       (jdbc/db-do-commands db-spec destroy-database-commands)))))
 
 ;; Def multiple assertions for the same test
 (defmacro with-matrix-assertions


### PR DESCRIPTION
# Description of change
The test as currently written don't check if the machine that's running the server instance is a test machine, this is normally fine, but there are certain scenarios where this can be connected to a non-test instance, this adds safety by checking the hostname of the server running mssql against a whitelist.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
