### PR TITLE
Extract database key and if nil return an empty string

### DIFF
--- a/src/tap_mssql/config.clj
+++ b/src/tap_mssql/config.clj
@@ -11,7 +11,7 @@
 (defn ->conn-map*
   [config]
   (let [conn-map {:dbtype "sqlserver"
-                  :dbname (config "database" "")
+                  :dbname (or (config "database") "") ;; database is optional - if omitted it is set to an empty string
                   :host (config "host")
                   :port (or (config "port") 0) ;; port is optional - if omitted it is set to 0 for a dynamic port
                   :password (config "password")

--- a/test/tap_mssql/discover_config_test.clj
+++ b/test/tap_mssql/discover_config_test.clj
@@ -124,6 +124,11 @@
                        (get-in catalog-entry ["metadata" "database-name"])))
                 distinct)))))
 
+(deftest ^:integration verify-nil-database-succeeds
+  (let [nil-db-config (assoc test-db-config "database" nil)]
+    ;; This used to throw a java.lang.IllegalArgumentException
+    (is (map? (catalog/discover nil-db-config)))))
+
 (deftest ^:integration verify-full-catalog
   (let [expected-stream-names #{"another_database_with_a_table_dbo_another_empty_table"
                                 "database_with_a_table_dbo_empty_table"


### PR DESCRIPTION
# Description of change

When the database key exists but maps to a nil value, this returns incorrectly. In the absence of a specific dbname, jdbc expects this to be an empty string.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
