### PR TITLE
transform binary types to hex strings

### DIFF
--- a/src/tap_mssql/singer/transform.clj
+++ b/src/tap_mssql/singer/transform.clj
@@ -13,7 +13,7 @@
 
 (defn transform-field [catalog stream-name [k v]]
   (condp contains? (get-in catalog ["streams" stream-name "metadata" "properties" k "sql-datatype"])
-    #{"timestamp" "varbinary"}
+    #{"timestamp" "varbinary" "binary"}
     [k (transform-binary v)]
 
     #{"date"}

--- a/test/tap_mssql/core_sync_test.clj
+++ b/test/tap_mssql/core_sync_test.clj
@@ -153,15 +153,18 @@
            {"cuyahoga" {"metadata" {"properties" {"test1" {"sql-datatype" "varbinary"}
                                                   "test2" {"sql-datatype" "timestamp"}
                                                   "test3" {"sql-datatype" "date"}
+                                                  "test4" {"sql-datatype" "binary"}
                                                   "regular" {"sql-datatype" "fish"}}}}}}
           "cuyahoga"
           {"test1" (byte-array [0 0 0 0 0 0 0 10])
            "test2" (byte-array [0 0 0 0 0 0 0 10])
            "test3" (Date. 1565222400000)
+           "test4" (byte-array [0 0 0 0 0 0 0 10])
            "regular" {"should be" "unchanged"}})
          {"test1" "0x000000000000000A"
           "test2" "0x000000000000000A"
           "test3" "2019-08-08T00:00:00+00:00"
+          "test4" "0x000000000000000A"
           "regular" {"should be" "unchanged"}})))
 
 (deftest transform-binary-test


### PR DESCRIPTION
# Description of change
During discovery, for columns of type `binary` the tap writes the schema as a string, but does not transform the data to a string, instead emitting it as a byte array.

This PR changes the tap to transform columns of type `binary` to a hex string.

# QA steps
 - [x] tested on cloned connection that was failing schema validation and is now passing
 
# Risks

# Rollback steps
 - revert this branch
