### PR TITLE
SUP-1168: Fallback to time now for sdc_deleted_at

### DIFF
--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -195,9 +195,9 @@
                   (let [record (as-> (select-keys result record-keys) rec
                                  (if (= "D" (get result "sys_change_operation"))
                                    (do
-                                     (when-not (get result "commit-time2")
+                                     (when-not (get result "commit-time")
                                        (log/warn "Found deleted record with no timestamp, falling back to current time."))
-                                     (assoc rec "_sdc_deleted_at" (or (get result "commit_time2")
+                                     (assoc rec "_sdc_deleted_at" (or (get result "commit_time")
                                                                       (.toString (java.time.Instant/now)))))
                                    rec))]
                     (singer-messages/write-record! stream-name st record catalog)

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -180,6 +180,10 @@
       (update-current-log-version stream-name db-log-version state)
       state)))
 
+(defn get-commit-time [result]
+  (or (get result "commit_time")
+      (.toString (java.time.Instant/now))))
+
 (defn log-based-sync
   [config catalog stream-name state]
   {:pre  [(= true (get-in state ["bookmarks" stream-name "initial_full_table_complete"]))]
@@ -197,8 +201,7 @@
                                    (do
                                      (when-not (get result "commit-time")
                                        (log/warn "Found deleted record with no timestamp, falling back to current time."))
-                                     (assoc rec "_sdc_deleted_at" (or (get result "commit_time")
-                                                                      (.toString (java.time.Instant/now)))))
+                                     (assoc rec "_sdc_deleted_at" (get-commit-time result)))
                                    rec))]
                     (singer-messages/write-record! stream-name st record catalog)
                     (->> (singer-bookmarks/update-last-pk-fetched stream-name bookmark-keys st record)

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -188,8 +188,7 @@
         bookmark-keys  (singer-bookmarks/get-bookmark-keys catalog stream-name)
         dbname         (get-in catalog ["streams" stream-name "metadata" "database-name"])
         db-log-version (get-current-log-version config catalog stream-name)
-        sql-params     (build-log-based-sql-query catalog stream-name state)
-        time-now       (.toString (java.time.Instant/now))]
+        sql-params     (build-log-based-sql-query catalog stream-name state)]
     (log/infof "Executing query: %s" sql-params)
     (singer-messages/write-activate-version! stream-name catalog state)
     (-> (reduce (fn [st result]

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -195,7 +195,11 @@
     (-> (reduce (fn [st result]
                   (let [record (as-> (select-keys result record-keys) rec
                                  (if (= "D" (get result "sys_change_operation"))
-                                   (assoc rec "_sdc_deleted_at" (get result "commit_time" time-now))
+                                   (do
+                                     (when-not (get result "commit-time2")
+                                       (log/warn "Found deleted record with no timestamp, falling back to current time."))
+                                     (assoc rec "_sdc_deleted_at" (or (get result "commit_time2")
+                                                                      (.toString (java.time.Instant/now)))))
                                    rec))]
                     (singer-messages/write-record! stream-name st record catalog)
                     (->> (singer-bookmarks/update-last-pk-fetched stream-name bookmark-keys st record)

--- a/test/tap_mssql/sync_log_based_test.clj
+++ b/test/tap_mssql/sync_log_based_test.clj
@@ -471,3 +471,18 @@
              (get (->> messages
                        (filter #(= "STATE" (% "type")))
                        last) "value"))))))
+
+(deftest ^:integration test-null-commit_time
+  "instant1.compareTo(instant2) returns
+     - a negative number if instant1 < instant2
+     - a zero if instant1 = instant2
+     - a positive number if instant1 > instant2"
+  (let [our-time (java.time.Instant/parse "2000-01-30T15:37:20.895Z")
+        our-str-time (.toString our-time)]
+    (is (neg? (.compareTo our-time
+                          (java.time.Instant/parse (logical/get-commit-time {"commit_time" nil})))))
+    (is (neg? (.compareTo our-time
+                          (java.time.Instant/parse (logical/get-commit-time {})))))
+    (is (= 0
+           (.compareTo our-time
+                       (java.time.Instant/parse (logical/get-commit-time {"commit_time" our-str-time})))))))


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-1168

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
    - We ran the unit tests and observed `_sdc_deleted_at` populate when we tried to `get` a bad key (like `"commit_time2"`)
 
# Risks
 - Low, seems to be a rare case that `"commit_time"` is `null`

# Rollback steps
 - revert this branch
