### PR TITLE
Bug/dates approaching 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           environment:
             DOCKERIZE_VERSION: v0.3.0
       - run:
-          name: 'Wait for Mongo'
+          name: 'Wait for MSSQL Docker'
           command: |
             dockerize -wait tcp://127.0.0.1:1433 -timeout 1m
             sleep 5

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -27,6 +27,13 @@
             (.appendPattern "yyyy-MM-dd'T'HH:mm:ss.SSSSSSX")
             (.toFormatter)))
 
+(defn- parse-timestamp-to-string [ts]
+  (-> ts
+      (.toLocalDateTime)
+      (.atOffset java.time.ZoneOffset/UTC)
+      (.format df)
+      (.replaceAll "\\.?(000)+Z" "Z")))
+
 ;; date - 0001-01-01 through 9999-12-31
 ;; datetime - 1753-01-01 through 9999-12-31 and 00:00:00 through 23:59:59.997 and no TZ
 ;; datetime2 - 0001-01-01 through 9999-12-31 and 00:00:00 through 23:59:59.9999999 and no TZ
@@ -63,13 +70,6 @@
     (.toString v)
 
     v))
-
-(defn- parse-timestamp-to-string [ts]
-  (-> v
-      (.toLocalDateTime)
-      (.atOffset java.time.ZoneOffset/UTC)
-      (.format df)
-      (.replaceAll "\\.?(000)+Z" "Z")))
 
 (def include-db-and-schema-names-in-messages? (atom false))
 

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -52,31 +52,24 @@
 (defn serialize-datetimes [k v]
   (condp contains? (type v)
     #{java.sql.Timestamp}
-    (-> (.toLocalDateTime v)
-        (.atOffset java.time.ZoneOffset/UTC)
-        (.format df)
-        (.replaceAll "\\.?(000)+Z" "Z"))
-
-
-    #_(->> (.toInstant v)
-         (.format df)) ;; use the SimpleDateFormat here
-
-    #{java.sql.Time}
-    (.toString v)
-
-    #{java.sql.Date}
-    (.toString v)
+    (pase-timestamp-to-string v)
 
     #{microsoft.sql.DateTimeOffset}
     (-> v
         (.getTimestamp)
-        (.toLocalDateTime)
-        (.atOffset java.time.ZoneOffset/UTC)
-        (.format df)
-        (.replaceAll "\\.?(000)+Z" "Z"))
-    #_(.. v getTimestamp toInstant (format v))
+        (parse-timestamp-to-string))
+
+    #{java.sql.Time java.sql.Date}
+    (.toString v)
 
     v))
+
+(defn- parse-timestamp-to-string [ts]
+  (-> v
+      (.toLocalDateTime)
+      (.atOffset java.time.ZoneOffset/UTC)
+      (.format df)
+      (.replaceAll "\\.?(000)+Z" "Z")))
 
 (def include-db-and-schema-names-in-messages? (atom false))
 

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -32,7 +32,7 @@
       (.toLocalDateTime)
       (.atOffset java.time.ZoneOffset/UTC)
       (.format df)
-      (.replaceAll "\\.?(000)+Z" "Z")))
+      (.replace ".000000Z" "Z")))
 
 ;; date - 0001-01-01 through 9999-12-31
 ;; datetime - 1753-01-01 through 9999-12-31 and 00:00:00 through 23:59:59.997 and no TZ

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -23,9 +23,27 @@
          "ACTIVATE_VERSION"
          (message "version"))))
 
-;; Using java.text.SimpleDateFormat seems to work on java.sql.Timestamp
-(def df (doto (java.text.SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss'Z'")
-          (.setTimeZone (java.util.TimeZone/getTimeZone "UTC"))))
+(def df (-> (java.time.format.DateTimeFormatterBuilder.)
+            (.appendPattern "yyyy-MM-dd'T'HH:mm:ss.SX")
+            ;;(.appendZoneId java.time.ZoneOffset/UTC)
+            (.toFormatter)))
+
+;; date - 0001-01-01 through 9999-12-31
+;; datetime - 1753-01-01 through 9999-12-31 and 00:00:00 through 23:59:59.997 and no TZ
+;; datetime2 - 0001-01-01 through 9999-12-31 and 00:00:00 through 23:59:59.9999999 and no TZ
+;; datetimeoffset - 0001-01-01 through 9999-12-31 and 00:00:00 through 23:59:59.9999999 and -14:00 through +14:00
+;; smalldatetime - 1900-01-01 through 2079-06-06 and 00:00:00 through 23:59:59 and no TZ
+;; time - 00:00:00.0000000 through 23:59:59.9999999
+
+;; 1) The tap should always write ISO8601 dates
+;; 2) In the absence of time, we should add 00:00:00
+;; 3) In the absence of a TZ, we should add Z (assume UTC)
+;; 4) In the presence of a TZ, we should emit with the appropriate +/- 00:00
+
+;; cREATES A TABLE
+;; adds some columns
+;; inserts data
+;; calls
 
 ;; Passed to the json serializer as value-converter fn
 ;; Needed to convert java.sql.Date types to json strings

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -46,27 +46,17 @@
 ;; 3) In the absence of a TZ, we should add Z (assume UTC)
 ;; 4) In the presence of a TZ, we should emit with the appropriate +/- 00:00
 ;; 5) In the absense of a date, we should emit the time in the format HH:mm:ss.ffffffff
-
-;; creates a table
-;; adds some columns
-;; inserts data
-;; calls
-
-;; Passed to the json serializer as value-converter fn
-;; Needed to convert java.sql.Date types to json strings
-;; Both java.sql.Timestamp and microsoft.sql.DateTimeOffset were observed
-;; having funny behavior approaching year 0000.
 (defn serialize-datetimes [k v]
   (condp contains? (type v)
-    #{java.sql.Timestamp}
+    #{java.sql.Timestamp} ;; Java type for datetime, datetime2, and smalldatetime column types
     (parse-timestamp-to-string v)
 
-    #{microsoft.sql.DateTimeOffset}
+    #{microsoft.sql.DateTimeOffset} ;; Java type for datetimeoffset columns
     (-> v
         (.getTimestamp)
         (parse-timestamp-to-string))
 
-    #{java.sql.Time java.sql.Date}
+    #{java.sql.Time java.sql.Date} ;; Java type for Time/Date columns respectively
     (.toString v)
 
     v))

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -32,7 +32,8 @@
       (.toLocalDateTime)
       (.atOffset java.time.ZoneOffset/UTC)
       (.format df)
-      (.replace ".000000Z" "Z")))
+      (.replace "000Z" "Z")
+      (.replace ".000Z" "Z")))
 
 ;; date - 0001-01-01 through 9999-12-31
 ;; datetime - 1753-01-01 through 9999-12-31 and 00:00:00 through 23:59:59.997 and no TZ

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -52,7 +52,7 @@
 (defn serialize-datetimes [k v]
   (condp contains? (type v)
     #{java.sql.Timestamp}
-    (pase-timestamp-to-string v)
+    (parse-timestamp-to-string v)
 
     #{microsoft.sql.DateTimeOffset}
     (-> v

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -32,8 +32,9 @@
       (.toLocalDateTime)
       (.atOffset java.time.ZoneOffset/UTC)
       (.format df)
-      (.replace "000Z" "Z")
-      (.replace ".000Z" "Z")))
+      (.replace "000Z" "Z") ;; replacing microseconds because dates are saved as bookmarks and mssql does not support string datetimes being more precise than the column type
+      (.replace ".000Z" "Z") ;; same with milliseconds
+      ))
 
 ;; date - 0001-01-01 through 9999-12-31
 ;; datetime - 1753-01-01 through 9999-12-31 and 00:00:00 through 23:59:59.997 and no TZ

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -23,6 +23,10 @@
          "ACTIVATE_VERSION"
          (message "version"))))
 
+;; Using java.text.SimpleDateFormat seems to work on java.sql.Timestamp
+(def df (doto (java.text.SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss'Z'")
+          (.setTimeZone (java.util.TimeZone/getTimeZone "UTC"))))
+
 ;; Passed to the json serializer as value-converter fn
 ;; Needed to convert java.sql.Date types to json strings
 ;; Both java.sql.Timestamp and microsoft.sql.DateTimeOffset were observed
@@ -30,7 +34,7 @@
 (defn serialize-datetimes [k v]
   (condp contains? (type v)
     #{java.sql.Timestamp}
-    (.. v toInstant toString)
+    (.format df v) ;; use the SimpleDateFormat here
 
     #{java.sql.Time java.sql.Date}
     (.toString v)

--- a/src/tap_mssql/sync_strategies/incremental.clj
+++ b/src/tap_mssql/sync_strategies/incremental.clj
@@ -30,6 +30,15 @@
               [replication-key-value])
       sql-params)))
 
+(comment
+  ;; The bug occurs when a java.sql.Timestamp comes through the JDBC driver and
+  ;; makes it to the messages/serialize-datetimes function as we serialize to
+  ;; a JSON string.
+  ;; #inst "0001-01-01T00:00:00.000000000-00:00"
+  (-> (java.sql.Timestamp. -62135769600000)
+      (.toInstant))
+  )
+
 (defn sync-and-write-messages!
   "Syncs all records, states, returns the latest state. Ensures that the
   bookmark we have for this stream matches our understanding of the fields

--- a/src/tap_mssql/sync_strategies/incremental.clj
+++ b/src/tap_mssql/sync_strategies/incremental.clj
@@ -31,6 +31,17 @@
       sql-params)))
 
 (comment
+
+  ;; This might be another option using java.time classes
+  (let [f (-> (java.time.format.DateTimeFormatterBuilder.)
+              (.appendPattern "yyyy-MM-dd'T'HH:mm:ssX")
+              ;;(.appendZoneId java.time.ZoneOffset/UTC)
+              (.toFormatter))
+        d (-> (.toLocalDateTime (java.sql.Timestamp. -62135769600000))
+              (.atOffset java.time.ZoneOffset/UTC))]
+    ;;d
+    (.format d f)
+    )
   ;; The bug occurs when a java.sql.Timestamp comes through the JDBC driver and
   ;; makes it to the messages/serialize-datetimes function as we serialize to
   ;; a JSON string.

--- a/src/tap_mssql/sync_strategies/incremental.clj
+++ b/src/tap_mssql/sync_strategies/incremental.clj
@@ -30,26 +30,6 @@
               [replication-key-value])
       sql-params)))
 
-(comment
-
-  ;; This might be another option using java.time classes
-  (let [f (-> (java.time.format.DateTimeFormatterBuilder.)
-              (.appendPattern "yyyy-MM-dd'T'HH:mm:ssX")
-              ;;(.appendZoneId java.time.ZoneOffset/UTC)
-              (.toFormatter))
-        d (-> (.toLocalDateTime (java.sql.Timestamp. -62135769600000))
-              (.atOffset java.time.ZoneOffset/UTC))]
-    ;;d
-    (.format d f)
-    )
-  ;; The bug occurs when a java.sql.Timestamp comes through the JDBC driver and
-  ;; makes it to the messages/serialize-datetimes function as we serialize to
-  ;; a JSON string.
-  ;; #inst "0001-01-01T00:00:00.000000000-00:00"
-  (-> (java.sql.Timestamp. -62135769600000)
-      (.toInstant))
-  )
-
 (defn sync-and-write-messages!
   "Syncs all records, states, returns the latest state. Ensures that the
   bookmark we have for this stream matches our understanding of the fields


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SRCE-2282
Change how we serialize date times to avoid issues when approaching year 0.

This change avoids converting the java.sql.Timestamp into an Instant, because the conversion of 0001-01-01 was being changed to 0000-12-30 when converting to an Instant.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 
# Risks
Low

# Rollback steps
 - revert this branch
