### PR TITLE
Throw an error if min_valid_version is null

### DIFF
--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -38,8 +38,8 @@
 
 (defn get-min-valid-version [config dbname table-name]
   (let [object-id (get-object-id-by-table-name config dbname table-name)
-        sql-query (format "SELECT CHANGE_TRACKING_MIN_VALID_VERSION(%d) as min_valid_version" object-id)
-        _         (log/infof "Executing query: %s" sql-query)]
+        sql-query (format "SELECT CHANGE_TRACKING_MIN_VALID_VERSION(%d) as min_valid_version" object-id)]
+    (log/infof "Executing query: %s" sql-query)
     (-> (jdbc/query (assoc (config/->conn-map config) :dbname dbname) [sql-query])
         first
         :min_valid_version)))

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -111,7 +111,7 @@
         table-name          (get-in catalog ["streams" stream-name "table_name"])
         dbname              (get-in catalog ["streams" stream-name "metadata" "database-name"])
         current-log-version (get-in state ["bookmarks" stream-name "current_log_version"])
-        min-valid-version   (get-min-valid-version config dbname table-name)]
+        min-valid-version   (get-min-valid-version config dbname schema-name table-name)]
     (if (nil? current-log-version)
       true
       (let [out-of-date? (> min-valid-version current-log-version)]

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -97,6 +97,12 @@
         min-valid-version   (-> (jdbc/query (assoc (config/->conn-map config) :dbname dbname) [sql-query])
                                 first
                                 :min_valid_version)]
+    (when (nil? min-valid-version)
+      (throw (IllegalArgumentException.
+              (format "The min_valid_version for object-id %s (table name: %s) was NULL. Cannot compare NULL to %s"
+                      object-id
+                      table-name
+                      current-log-version))))
 
     (if (nil? current-log-version)
       true

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -94,15 +94,15 @@
         object-id           (get-object-id-by-table-name config dbname table-name)
         sql-query           (format "SELECT CHANGE_TRACKING_MIN_VALID_VERSION(%d) as min_valid_version" object-id)
         _                   (log/infof "Executing query: %s" sql-query)
-        min-valid-version   (-> (jdbc/query (assoc (config/->conn-map config) :dbname dbname) [sql-query])
-                                first
-                                :min_valid_version)]
-    (when (nil? min-valid-version)
-      (throw (IllegalArgumentException.
-              (format "The min_valid_version for object-id %s (table name: %s) was NULL. Cannot compare NULL to %s"
-                      object-id
-                      table-name
-                      current-log-version))))
+        min-valid-version   (or (-> (jdbc/query (assoc (config/->conn-map config) :dbname dbname) [sql-query])
+                                    first
+                                    :min_valid_version)
+                                (throw (IllegalArgumentException.
+                                        (format (str "The min_valid_version for object-id %s "
+                                                     "(table name: %s) was NULL. Cannot compare NULL to %s")
+                                                object-id
+                                                table-name
+                                                current-log-version))))]
 
     (if (nil? current-log-version)
       true

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -10,7 +10,9 @@
             [clojure.string :as string]
             [clojure.java.jdbc :as jdbc]))
 
-(defn get-change-tracking-tables* [config dbname]
+(defn get-change-tracking-tables*
+  "Structure: {\"schema_name\" [\"table1\" \"table2\" ...] ...}"
+  [config dbname]
   (reduce (fn [acc val] (assoc acc
                                (:schema_name val)
                                (-> (get acc (:schema_name val))
@@ -61,7 +63,8 @@
                            "Change Tracking is not enabled for database: %s")
                       stream-name
                       dbname))))
-    (when (not (contains? (get (get-change-tracking-tables config dbname) schema-name) table-name))
+    (when (not (contains? (-> (get-change-tracking-tables config dbname)
+                              (get schema-name)) table-name))
       (throw (UnsupportedOperationException.
               (format (str "Cannot sync stream: %s using log-based replication. "
                            "Change Tracking is not enabled for table: %s")

--- a/test/tap_mssql/sync_log_based_test.clj
+++ b/test/tap_mssql/sync_log_based_test.clj
@@ -33,6 +33,8 @@
   (let [db-spec (config/->conn-map config)]
     (jdbc/db-do-commands db-spec ["CREATE DATABASE log_based_sync_test"])
     (jdbc/db-do-commands (assoc db-spec :dbname "log_based_sync_test")
+                         ["CREATE SCHEMA schema_with_conflict"])
+    (jdbc/db-do-commands (assoc db-spec :dbname "log_based_sync_test")
                          ["CREATE SCHEMA schema_with_table"])
     (jdbc/db-do-commands (assoc db-spec :dbname "log_based_sync_test")
                          [(jdbc/create-table-ddl
@@ -45,6 +47,9 @@
                            "data_table_2"
                            [[:id "uniqueidentifier NOT NULL PRIMARY KEY DEFAULT NEWID()"]
                             [:value "int"]])])
+    ;; Same table as below, created first to check for unexpected failures with ignoring schema
+    (jdbc/db-do-commands (assoc db-spec :dbname "log_based_sync_test")
+                         ["CREATE TABLE schema_with_conflict.data_table (id uniqueidentifier NOT NULL PRIMARY KEY DEFAULT NEWID(), value int)"])
     (jdbc/db-do-commands (assoc db-spec :dbname "log_based_sync_test")
                          ["CREATE TABLE schema_with_table.data_table (id uniqueidentifier NOT NULL PRIMARY KEY DEFAULT NEWID(), value int)"])))
 


### PR DESCRIPTION
# Description of change
In logical replication, sometimes our query here returns `nil`
https://github.com/singer-io/tap-mssql/blob/1bfc58de63a695512c74c57a32710d450866ae07/src/tap_mssql/sync_strategies/logical.clj#L95-L99

And when that happens, the tap will eventually try `(> nil 12345)` which causes a `java.lang.NullPointerException`. 

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
    - Ran the tap
 
# Risks
- Low

# Rollback steps
 - revert this branch
