### PR TITLE
Use a read-only cursor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,16 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "project.clj" }}
       - run:
+          name: 'Install Dockerize'
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run:
+          name: 'Wait for MSSQL Docker'
+          command: |
+            dockerize -wait tcp://127.0.0.1:1433 -timeout 1m
+            sleep 5
+      - run:
           name: Test
           command: |
             bin/test

--- a/src/tap_mssql/sync_strategies/common.clj
+++ b/src/tap_mssql/sync_strategies/common.clj
@@ -1,5 +1,12 @@
 (ns tap-mssql.sync-strategies.common
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string])
+  (:import [com.microsoft.sqlserver.jdbc SQLServerResultSet]))
+
+(def result-set-opts {:raw? true
+                      ;; Using SQLServerResultSet/TYPE_SS_SERVER_CURSOR_FORWARD_ONLY raises:
+                      ;; com.microsoft.sqlserver.jdbc.TDSParser throwUnexpectedTokenException
+                      :result-type SQLServerResultSet/TYPE_FORWARD_ONLY
+                      :concurrency SQLServerResultSet/CONCUR_READ_ONLY})
 
 ;; Square brackets or quotes can be used interchangeably to sanitize names. Square brackets
 ;; are used by SSMS so we are using the same pattern.

--- a/src/tap_mssql/sync_strategies/full.clj
+++ b/src/tap_mssql/sync_strategies/full.clj
@@ -7,7 +7,8 @@
             [tap-mssql.sync-strategies.common :as common]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [clojure.java.jdbc :as jdbc]))
+            [clojure.java.jdbc :as jdbc])
+  (:import [com.microsoft.sqlserver.jdbc SQLServerResultSet]))
 
 (defn get-max-pk-values [config catalog stream-name state]
   (let [dbname        (get-in catalog ["streams" stream-name "metadata" "database-name"])
@@ -127,7 +128,9 @@
                 (jdbc/reducible-query (assoc (config/->conn-map config)
                                              :dbname dbname)
                                       sql-params
-                                      {:raw? true}))
+                                      {:raw? true
+                                       :result-type SQLServerResultSet/TYPE_SS_SERVER_CURSOR_FORWARD_ONLY
+                                       :concurrency :read-only}))
         (update-in ["bookmarks" stream-name] dissoc "last_pk_fetched" "max_pk_values"))))
 
 (defn sync!

--- a/src/tap_mssql/sync_strategies/full.clj
+++ b/src/tap_mssql/sync_strategies/full.clj
@@ -7,8 +7,7 @@
             [tap-mssql.sync-strategies.common :as common]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [clojure.java.jdbc :as jdbc])
-  (:import [com.microsoft.sqlserver.jdbc SQLServerResultSet]))
+            [clojure.java.jdbc :as jdbc]))
 
 (defn get-max-pk-values [config catalog stream-name state]
   (let [dbname        (get-in catalog ["streams" stream-name "metadata" "database-name"])
@@ -128,9 +127,7 @@
                 (jdbc/reducible-query (assoc (config/->conn-map config)
                                              :dbname dbname)
                                       sql-params
-                                      {:raw? true
-                                       :result-type SQLServerResultSet/TYPE_SS_SERVER_CURSOR_FORWARD_ONLY
-                                       :concurrency :read-only}))
+                                      common/result-set-opts))
         (update-in ["bookmarks" stream-name] dissoc "last_pk_fetched" "max_pk_values"))))
 
 (defn sync!

--- a/src/tap_mssql/sync_strategies/incremental.clj
+++ b/src/tap_mssql/sync_strategies/incremental.clj
@@ -6,8 +6,7 @@
             [tap-mssql.sync-strategies.common :as common]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [clojure.java.jdbc :as jdbc])
-  (:import [com.microsoft.sqlserver.jdbc SQLServerResultSet]))
+            [clojure.java.jdbc :as jdbc]))
 
 (defn build-incremental-sync-query
   [stream-name schema-name table-name record-keys replication-key state]
@@ -57,9 +56,7 @@
             (jdbc/reducible-query (assoc (config/->conn-map config)
                                          :dbname dbname)
                                   sql-params
-                                  {:raw? true
-                                   :result-type SQLServerResultSet/TYPE_SS_SERVER_CURSOR_FORWARD_ONLY
-                                   :concurrency :read-only}))))
+                                  common/result-set-opts))))
 
 (defn sync!
   [config catalog stream-name state]

--- a/src/tap_mssql/sync_strategies/incremental.clj
+++ b/src/tap_mssql/sync_strategies/incremental.clj
@@ -6,7 +6,8 @@
             [tap-mssql.sync-strategies.common :as common]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [clojure.java.jdbc :as jdbc]))
+            [clojure.java.jdbc :as jdbc])
+  (:import [com.microsoft.sqlserver.jdbc SQLServerResultSet]))
 
 (defn build-incremental-sync-query
   [stream-name schema-name table-name record-keys replication-key state]
@@ -56,7 +57,9 @@
             (jdbc/reducible-query (assoc (config/->conn-map config)
                                          :dbname dbname)
                                   sql-params
-                                  {:raw? true}))))
+                                  {:raw? true
+                                   :result-type SQLServerResultSet/TYPE_SS_SERVER_CURSOR_FORWARD_ONLY
+                                   :concurrency :read-only}))))
 
 (defn sync!
   [config catalog stream-name state]

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -8,8 +8,7 @@
             [tap-mssql.sync-strategies.common :as common]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [clojure.java.jdbc :as jdbc])
-  (:import [com.microsoft.sqlserver.jdbc SQLServerResultSet]))
+            [clojure.java.jdbc :as jdbc]))
 
 (defn get-change-tracking-tables*
   "Structure: {\"schema_name\" [\"table1\" \"table2\" ...] ...}"
@@ -230,9 +229,7 @@
                 (jdbc/reducible-query (assoc (config/->conn-map config)
                                              :dbname dbname)
                                       sql-params
-                                      {:raw? true
-                                       :result-type SQLServerResultSet/TYPE_SS_SERVER_CURSOR_FORWARD_ONLY
-                                       :concurrency :read-only}))
+                                      common/result-set-opts))
         ;; maybe-update in case no rows were synced
         (maybe-update-current-log-version stream-name db-log-version)
         ;; last_pk_fetched indicates an interruption, and should be gone

--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -8,7 +8,8 @@
             [tap-mssql.sync-strategies.common :as common]
             [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [clojure.java.jdbc :as jdbc]))
+            [clojure.java.jdbc :as jdbc])
+  (:import [com.microsoft.sqlserver.jdbc SQLServerResultSet]))
 
 (defn get-change-tracking-tables*
   "Structure: {\"schema_name\" [\"table1\" \"table2\" ...] ...}"
@@ -229,7 +230,9 @@
                 (jdbc/reducible-query (assoc (config/->conn-map config)
                                              :dbname dbname)
                                       sql-params
-                                      {:raw? true}))
+                                      {:raw? true
+                                       :result-type SQLServerResultSet/TYPE_SS_SERVER_CURSOR_FORWARD_ONLY
+                                       :concurrency :read-only}))
         ;; maybe-update in case no rows were synced
         (maybe-update-current-log-version stream-name db-log-version)
         ;; last_pk_fetched indicates an interruption, and should be gone


### PR DESCRIPTION
# Description of change

To avoid certain types of row locking, we should define the cursor type and concurrency policy for our ResultSet objects.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
