### PR TITLE
Bump to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.0
+  * Configure ResultSet options for concurrency mode and cursor type [#25](https://github.com/singer-io/tap-mssql/pull/25)
+
 ## 1.5.2
   * Clarify error messages in edge case when change tracking is not available [#24](https://github.com/singer-io/tap-mssql/pull/24)
   * Fix edge case where two identically named tables in different schemas have different change tracking status [#24](https://github.com/singer-io/tap-mssql/pull/24)

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.5.2"
+  "1.6.0"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
# Description of change

Releases the 1.6.0 changes to use a read-only, forward cursor on ResultSets

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 
Confirmed that this alleviates the lock contention.

# Risks

# Rollback steps
 - revert this branch
