### PR TITLE
Fix bugs with a View being interrupted while syncing

### DIFF
--- a/src/tap_mssql/singer/bookmarks.clj
+++ b/src/tap_mssql/singer/bookmarks.clj
@@ -44,15 +44,10 @@
              replication-key)))
 
 (defn update-last-pk-fetched [stream-name bookmark-keys state record]
-  (assoc-in state
-            ["bookmarks" stream-name "last_pk_fetched"]
-            (zipmap bookmark-keys (map (partial get record) bookmark-keys))))
-
-
-(comment
-
-  (get-in catalog ["streams"
-                "full_table_interruptible_sync_test_dbo_view_with_table_ids"])
-
-
-  )
+  ;; bookmark-keys can be nil under certain conditions:
+  ;; ex: if a view is missing view-key-properties
+  (if bookmark-keys
+    (assoc-in state
+              ["bookmarks" stream-name "last_pk_fetched"]
+              (zipmap bookmark-keys (map (partial get record) bookmark-keys)))
+    state))

--- a/src/tap_mssql/singer/bookmarks.clj
+++ b/src/tap_mssql/singer/bookmarks.clj
@@ -19,10 +19,16 @@
                                                     stream-name
                                                     "metadata"
                                                     "properties"]))))
-        table-key-properties (get-in catalog ["streams"
-                                              stream-name
-                                              "metadata"
-                                              "table-key-properties"])]
+        is-view? (get-in catalog ["streams" stream-name "metadata" "is-view"])
+        table-key-properties (if is-view?
+                               (get-in catalog ["streams"
+                                                stream-name
+                                                "metadata"
+                                                "view-key-properties"])
+                               (get-in catalog ["streams"
+                                                stream-name
+                                                "metadata"
+                                                "table-key-properties"]))]
     (if (not (nil? replication-key))
       [replication-key]
       (if (not (nil? timestamp-column))
@@ -41,3 +47,12 @@
   (assoc-in state
             ["bookmarks" stream-name "last_pk_fetched"]
             (zipmap bookmark-keys (map (partial get record) bookmark-keys))))
+
+
+(comment
+
+  (get-in catalog ["streams"
+                "full_table_interruptible_sync_test_dbo_view_with_table_ids"])
+
+
+  )

--- a/src/tap_mssql/singer/messages.clj
+++ b/src/tap_mssql/singer/messages.clj
@@ -152,9 +152,11 @@
 
 (def records-since-last-state (atom 0))
 
+(def record-buffer-size 100)
+
 (defn write-state-buffered! [stream-name state]
   (swap! records-since-last-state inc)
-  (if (> @records-since-last-state 100)
+  (if (> @records-since-last-state record-buffer-size)
     (do
       (reset! records-since-last-state 0)
       (write-state! stream-name state))


### PR DESCRIPTION
# Description of change

A View can be synced with or without `view-key-properties` being set. If interrupted without `view-key-properties`, it should not emit a bad state. If interrupted with `view-key-properties` set, it should be resumable.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
