### PR TITLE
Fix/discovery database permissions error

### DIFF
--- a/test/tap_mssql/discover_permissions_test.clj
+++ b/test/tap_mssql/discover_permissions_test.clj
@@ -1,0 +1,81 @@
+(ns tap-mssql.discover-permissions-test
+  (:require [tap-mssql.catalog :as catalog]
+            [tap-mssql.config :as config]
+            [clojure.test :refer [is deftest use-fixtures]]
+            [clojure.java.io :as io]
+            [clojure.java.jdbc :as jdbc]
+            [clojure.set :as set]
+            [clojure.string :as string]
+            [tap-mssql.core :refer :all]
+            [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
+                                          test-db-config]]))
+
+(defn get-destroy-database-command
+  [database]
+  (format "DROP DATABASE IF EXISTS %s" (:table_cat database)))
+
+(defn maybe-destroy-test-db
+  []
+  (let [destroy-database-commands (->> [{:table_cat "empty_database"}
+                                        {:table_cat "database_with_a_table"}
+                                        {:table_cat "database_with_table_valued_function"}]
+                                       (filter catalog/non-system-database?)
+                                       (map get-destroy-database-command))]
+    (let [db-spec (config/->conn-map test-db-config)]
+      (jdbc/db-do-commands db-spec destroy-database-commands))))
+
+(defn create-test-db
+  []
+  (let [db-spec (config/->conn-map test-db-config)]
+    (jdbc/db-do-commands db-spec ["CREATE DATABASE empty_database"
+                                  "CREATE DATABASE database_with_a_table"
+                                  "CREATE DATABASE database_with_table_valued_function"])
+    (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
+                         [(jdbc/create-table-ddl :empty_table [[:id "int"]])])
+    (when (empty? (jdbc/query (assoc db-spec :dbname "database_with_a_table")
+                       "SELECT principal_id FROM sys.server_principals WHERE name = 'SingerTestUser'"))
+      (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
+                           ["CREATE LOGIN SingerTestUser WITH PASSWORD = 'ABCD12345$%'"]))
+    (when (empty? (jdbc/query (assoc db-spec :dbname "database_with_a_table")
+                       "SELECT principal_id FROM sys.database_principals WHERE name = 'SingerTestUser'"))
+      (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
+                           ["CREATE USER SingerTestUser FOR LOGIN SingerTestUser"
+                            "GRANT SELECT ON dbo.empty_table TO SingerTestUser"]))
+    (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
+                         ["CREATE VIEW empty_table_ids
+                           AS
+                           SELECT id FROM empty_table"])
+    (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
+                         ["CREATE FUNCTION table_valued_test(@input_value int)
+                           RETURNS @result table (a_value int)
+                           AS
+                           BEGIN
+                               INSERT INTO @result VALUES(@input_value + 1)
+                               RETURN
+                           END"])))
+
+(defn test-db-fixture [f]
+  (with-out-and-err-to-dev-null
+    (maybe-destroy-test-db)
+    (create-test-db)
+    (f)))
+
+(use-fixtures :each test-db-fixture)
+
+(deftest ^:integration verify-populated-catalog
+  (is (let [stream-names (set (map #(get % "stream") (vals ((catalog/discover (assoc test-db-config
+                                                                                     "user" "SingerTestUser"
+                                                                                     "password" "ABCD12345$%"))
+                                                            "streams"))))]
+        (stream-names "empty_table")))
+  (is (let [stream-names (set (map #(get % "stream") (vals ((catalog/discover (assoc test-db-config
+                                                                                     "user" "SingerTestUser"
+                                                                                     "password" "ABCD12345$%"))
+                                                            "streams"))))]
+        (stream-names "empty_table_ids")))
+  ;; Table-Valued functions should not be discovered
+  (is (nil? (let [stream-names (set (map #(get % "stream") (vals ((catalog/discover (assoc test-db-config
+                                                                                     "user" "SingerTestUser"
+                                                                                     "password" "ABCD12345$%"))
+                                                                  "streams"))))]
+              (stream-names "table_valued_test")))))

--- a/test/tap_mssql/discover_permissions_test.clj
+++ b/test/tap_mssql/discover_permissions_test.clj
@@ -16,9 +16,9 @@
 
 (defn maybe-destroy-test-db
   []
-  (let [destroy-database-commands (->> [{:table_cat "empty_database"}
+  (let [destroy-database-commands (->> [{:table_cat "not_authorized_database"}
                                         {:table_cat "database_with_a_table"}
-                                        {:table_cat "database_with_table_valued_function"}]
+                                        {:table_cat "not_authorized_database_too"}]
                                        (filter catalog/non-system-database?)
                                        (map get-destroy-database-command))]
     (let [db-spec (config/->conn-map test-db-config)]
@@ -27,20 +27,17 @@
 (defn create-test-db
   []
   (let [db-spec (config/->conn-map test-db-config)]
-    (jdbc/db-do-commands db-spec ["CREATE DATABASE empty_database"
+    (jdbc/db-do-commands db-spec ["CREATE DATABASE not_authorized_database"
                                   "CREATE DATABASE database_with_a_table"
-                                  "CREATE DATABASE database_with_table_valued_function"])
+                                  "CREATE DATABASE not_authorized_database_too"])
+    ;; Create Tables
     (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
                          [(jdbc/create-table-ddl :empty_table [[:id "int"]])])
-    (when (empty? (jdbc/query (assoc db-spec :dbname "database_with_a_table")
-                       "SELECT principal_id FROM sys.server_principals WHERE name = 'SingerTestUser'"))
-      (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
-                           ["CREATE LOGIN SingerTestUser WITH PASSWORD = 'ABCD12345$%'"]))
-    (when (empty? (jdbc/query (assoc db-spec :dbname "database_with_a_table")
-                       "SELECT principal_id FROM sys.database_principals WHERE name = 'SingerTestUser'"))
-      (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
-                           ["CREATE USER SingerTestUser FOR LOGIN SingerTestUser"
-                            "GRANT SELECT ON dbo.empty_table TO SingerTestUser"]))
+    (jdbc/db-do-commands (assoc db-spec :dbname "not_authorized_database")
+                         [(jdbc/create-table-ddl :empty_table [[:id "int"]])])
+    (jdbc/db-do-commands (assoc db-spec :dbname "not_authorized_database_too")
+                         [(jdbc/create-table-ddl :empty_table [[:id "int"]])])
+    ;; Create view/tvf for fun
     (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
                          ["CREATE VIEW empty_table_ids
                            AS
@@ -52,7 +49,18 @@
                            BEGIN
                                INSERT INTO @result VALUES(@input_value + 1)
                                RETURN
-                           END"])))
+                           END"])
+    ;; Create User if not exists
+    (when (empty? (jdbc/query (assoc db-spec :dbname "database_with_a_table")
+                              "SELECT principal_id FROM sys.server_principals WHERE name = 'SingerTestUser'"))
+      (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
+                           ["CREATE LOGIN SingerTestUser WITH PASSWORD = 'ABCD12345$%'"]))
+    (when (empty? (jdbc/query (assoc db-spec :dbname "database_with_a_table")
+                              "SELECT principal_id FROM sys.database_principals WHERE name = 'SingerTestUser'"))
+      (jdbc/db-do-commands (assoc db-spec :dbname "database_with_a_table")
+                           ["CREATE USER SingerTestUser FOR LOGIN SingerTestUser"
+                            "GRANT SELECT ON dbo.empty_table TO SingerTestUser"
+                            "GRANT SELECT ON dbo.empty_table_ids TO SingerTestUser"]))))
 
 (defn test-db-fixture [f]
   (with-out-and-err-to-dev-null
@@ -75,7 +83,17 @@
         (stream-names "empty_table_ids")))
   ;; Table-Valued functions should not be discovered
   (is (nil? (let [stream-names (set (map #(get % "stream") (vals ((catalog/discover (assoc test-db-config
-                                                                                     "user" "SingerTestUser"
-                                                                                     "password" "ABCD12345$%"))
+                                                                                           "user" "SingerTestUser"
+                                                                                           "password" "ABCD12345$%"))
                                                                   "streams"))))]
-              (stream-names "table_valued_test")))))
+              (stream-names "table_valued_test"))))
+
+  ;; Should not discover tables in non-permitted databases
+  (is (let [discovered-dbs (->> (get (catalog/discover (assoc test-db-config
+                                                              "user" "SingerTestUser"
+                                                              "password" "ABCD12345$%")) "streams")
+                                (map (fn [[_ schema]] (get-in schema ["metadata" "database-name"])))
+                                set)]
+        (empty? (clojure.set/intersection
+                 discovered-dbs
+                 #{"not_authorized_database" "not_authorized_database_too"})))))


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-1512

The behavior of tap-mssql, it seems, differs from the other database taps, in that, there are cases of permissions where a user doesn't have access to all databases, in which case the tap fails.

This PR handles a very specific permissions error that can occur during discovery to align this behavior with other database taps.

The solution to fall back to a try/catch pattern came from the apparent lack of ability to query a user's permissions on a database without first connecting to the database (at which point an exception would be raised if they have no access).

# QA steps
 - [X] manual qa steps passing (list below)
    - Ran through a bunch of queries on local test DB and wrote local integration test for this case
 
# Risks
Low, it's just error handling.

# Rollback steps
 - revert this branch, bump patch, release
