### PR TITLE
Update project's license to match repo's license

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,8 @@
   "1.6.2"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
-  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
-            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."
+            :url "https://www.gnu.org/licenses/agpl-3.0.en.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.cli "0.4.1"]
                  [org.clojure/data.json "0.2.6"]


### PR DESCRIPTION
# Description of change
No functional changes, this PR replaces the default `lein` generated license key/value in `project.clj` with AGPL to match the repository.

# QA steps
 - [ ] manual qa steps passing (list below)
    - N/A

# Risks
Low, this is just a metadata change to the file.

# Rollback steps
 - revert this branch
