### PR TITLE
Get the correct change tracking information in azure

### DIFF
--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -30,8 +30,10 @@
 (defn get-change-tracking-databases* [conf]
   (set (map #(:db_name %)
             (jdbc/query (config/->conn-map conf)
-                        [(str "SELECT DB_NAME(database_id) AS db_name "
-                              "FROM sys.change_tracking_databases")]))))
+                        [(str "SELECT DB.name AS db_name "
+                              "FROM sys.change_tracking_databases CTDB "
+                              "INNER JOIN sys.databases DB "
+                              "ON CTDB.database_id=DB.database_id")]))))
 
 (def get-change-tracking-databases (memoize get-change-tracking-databases*))
 


### PR DESCRIPTION
Co-authored-by: kamd

# Description of change
Same as #31 but brought into a branch on this PR so circleCI will run.

> Fixed #30, problem with incremental sync strategy database_id mismatch in Azure SQL.
> 
> DB_NAME can give inconsistent results with the database_ids from sys.change_tracking_databases on Azure SQL, this fix joins with sys.databases instead.

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
Ran this branch against an azure database that the tap was finding as not having change tracking enabled despite it being enabled.
 
# Risks

# Rollback steps
 - revert this branch
