### PR TITLE
Use default  LEIN java resolution. Resolve in $JAVA_HOME or PATH

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,5 +27,4 @@
                  ]
   :plugins [[lein-pprint "1.2.0"]]
   :main tap-mssql.core
-  :profiles {:uberjar {:aot [tap-mssql.core]}
-             :system {:java-cmd "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"}})
+  :profiles {:uberjar {:aot [tap-mssql.core]}})


### PR DESCRIPTION
# Description of change

Accoring to Clojure documentation. the default PATH resolution is to check in $JAVA_HOME then in path. It should be perfect for most usage.

This fix https://github.com/singer-io/tap-mssql/issues/11

# QA steps
 
# Risks
This may be considered a breaking change i. 

# Rollback steps
 - revert this branch
