### PR TITLE
v1.6.5: Only add read-only to query-based replication methods' connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.5
+  * Only adds `ApplicationIntent=ReadOnly` to query-based connections due to an issue with Change Tracking and secondary read replicas not supporting it [#52](https://github.com/singer-io/tap-mssql/pull/52)
+
 ## 1.6.4
   * Adds `ApplicationIntent=ReadOnly` to the connection string [#50](https://github.com/singer-io/tap-mssql/pull/50)
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.6.4"
+  "1.6.5"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."

--- a/src/tap_mssql/config.clj
+++ b/src/tap_mssql/config.clj
@@ -15,8 +15,7 @@
                   :host (config "host")
                   :port (or (config "port") 0) ;; port is optional - if omitted it is set to 0 for a dynamic port
                   :password (config "password")
-                  :user (config "user")
-                  :ApplicationIntent "ReadOnly"}
+                  :user (config "user")}
         conn-map (if (= "true" (config "ssl"))
                    ;; TODO: The only way I can get a test failure is by
                    ;; changing the code to say ":trustServerCertificate

--- a/src/tap_mssql/sync_strategies/full.clj
+++ b/src/tap_mssql/sync_strategies/full.clj
@@ -20,7 +20,11 @@
     (if (not (empty? bookmark-keys))
       (do
         (log/infof "Executing query: %s" (pr-str sql-query))
-        (->> (jdbc/query (assoc (config/->conn-map config) :dbname dbname) sql-query {:keywordize? false :identifiers identity})
+        (->> (jdbc/query (assoc (config/->conn-map config)
+                                :dbname dbname
+                                :ApplicationIntent "ReadOnly")
+                         sql-query
+                         {:keywordize? false :identifiers identity})
              first
              (assoc-in state ["bookmarks" stream-name "max_pk_values"])))
       state)))
@@ -125,7 +129,8 @@
                          (singer-messages/write-state-buffered! stream-name))))
                 state
                 (jdbc/reducible-query (assoc (config/->conn-map config)
-                                             :dbname dbname)
+                                             :dbname dbname
+                                             :ApplicationIntent "ReadOnly")
                                       sql-params
                                       common/result-set-opts))
         (update-in ["bookmarks" stream-name] dissoc "last_pk_fetched" "max_pk_values"))))

--- a/src/tap_mssql/sync_strategies/incremental.clj
+++ b/src/tap_mssql/sync_strategies/incremental.clj
@@ -54,7 +54,8 @@
                      (singer-messages/write-state-buffered! stream-name))))
             state
             (jdbc/reducible-query (assoc (config/->conn-map config)
-                                         :dbname dbname)
+                                         :dbname dbname
+                                         :ApplicationIntent "ReadOnly")
                                   sql-params
                                   common/result-set-opts))))
 


### PR DESCRIPTION
# Description of change
Only add application intent read only to query-based replication methods, due to the lack of support of Change Tracking on secondary read replicas (this application intent forces all queries for the connection to a replica, if available).

The symptom of this situation is a message like the following:

```
For databases that are members of a secondary availability replica, change tracking is not supported. Run change tracking queries on the databases in the primary availability replica.
```

# QA steps
 - [X] automated tests passing
 - [ ] manual qa steps passing (list below)
     - None, I expect the automation to find any issues
 
# Risks
Low, this is a reaction and fix for incorrectly documented behavior by Microsoft regarding #50

# Rollback steps
 - revert this branch, bump patch, and re-release
