### PR TITLE
Retry on check-connection to use ApplicationIntent in all cases without error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.6
+  * Handle cases where `ApplicationIntent=ReadOnly` is not doable for log-based sync's initial full table [#53](https://github.com/singer-io/tap-mssql/pull/53)
+
 ## 1.6.5
   * Only adds `ApplicationIntent=ReadOnly` to query-based connections due to an issue with Change Tracking and secondary read replicas not supporting it [#52](https://github.com/singer-io/tap-mssql/pull/52)
 

--- a/project.clj
+++ b/project.clj
@@ -18,9 +18,10 @@
                                               javax.jms/jms
                                               com.sun.jdmk/jmxtools
                                               com.sun.jmx/jmxri]]
+
                  ;; repl
-                 [org.clojure/tools.nrepl "0.2.13"]
-                 [cider/cider-nrepl "0.17.0"]
+                 [nrepl "0.6.0"] ;; For Lein 2.9.X
+                 [cider/cider-nrepl "0.25.4"] ;; For cider-emacs 0.26.1
 
                  ;; test
                  [org.clojure/data.generators "0.1.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.6.5"
+  "1.6.6"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."

--- a/src/tap_mssql/config.clj
+++ b/src/tap_mssql/config.clj
@@ -10,13 +10,14 @@
 
 (defn ->conn-map*
   [config]
-  (let [conn-map {:dbtype "sqlserver"
-                  :dbname (or (config "database") "") ;; database is optional - if omitted it is set to an empty string
-                  :host (config "host")
-                  :port (or (config "port") 0) ;; port is optional - if omitted it is set to 0 for a dynamic port
-                  :password (config "password")
-                  :user (config "user")}
-        conn-map (if (= "true" (config "ssl"))
+  (let [conn-map (cond-> {:dbtype "sqlserver"
+                          :dbname (or (config "database") "") ;; database is optional - if omitted it is set to an empty string
+                          :host (config "host")
+                          :port (or (config "port") 0) ;; port is optional - if omitted it is set to 0 for a dynamic port
+                          :password (config "password")
+                          :user (config "user")
+                          :ApplicationIntent "ReadOnly"}
+                   (= "true" (config "ssl"))
                    ;; TODO: The only way I can get a test failure is by
                    ;; changing the code to say ":trustServerCertificate
                    ;; false". In which case, truststores need to be
@@ -27,21 +28,20 @@
                           ;; Based on the [docs][1], we believe thet
                           ;; setting `authentication` to anything but
                           ;; `NotSpecified` (the default) activates SSL
-                          ;; for the connection and have verified that by
-                          ;; setting `trustServerCertificate` to `false`
-                          ;; with `authentication` set to `SqlPassword`
-                          ;; and observing SSL handshake errors. Because
-                          ;; of this, we don't believe it's necessary to
-                          ;; set `encrypt` to `true` as it used to be
-                          ;; prior to Driver version 6.0.
+                          ;; for the connection and have verified that
+                          ;; by setting `trustServerCertificate` to
+                          ;; `false` with `authentication` set to
+                          ;; `SqlPassword` and observing SSL handshake
+                          ;; errors. Because of this, we don't believe
+                          ;; it's necessary to set `encrypt` to `true`
+                          ;; as it used to be prior to Driver version
+                          ;; 6.0.
                           ;;
-                          ;; [1]: https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-2017
+                          ;; [1]:
+                          ;; https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-2017
                           :authentication "SqlPassword"
-                          :trustServerCertificate false
-                          :ApplicationIntent "ReadOnly")
-                   conn-map)]
+                          :trustServerCertificate false))]
     ;; returns conn-map and logs on successful connection
-    ;; TODO: Needs test to confirm happy path, first failure, both failure
     (loop [test-conn conn-map
            retry? true]
       (if-let [checked-conn (try

--- a/src/tap_mssql/config.clj
+++ b/src/tap_mssql/config.clj
@@ -28,17 +28,15 @@
                           ;; Based on the [docs][1], we believe thet
                           ;; setting `authentication` to anything but
                           ;; `NotSpecified` (the default) activates SSL
-                          ;; for the connection and have verified that
-                          ;; by setting `trustServerCertificate` to
-                          ;; `false` with `authentication` set to
-                          ;; `SqlPassword` and observing SSL handshake
-                          ;; errors. Because of this, we don't believe
-                          ;; it's necessary to set `encrypt` to `true`
-                          ;; as it used to be prior to Driver version
-                          ;; 6.0.
+                          ;; for the connection and have verified that by
+                          ;; setting `trustServerCertificate` to `false`
+                          ;; with `authentication` set to `SqlPassword`
+                          ;; and observing SSL handshake errors. Because
+                          ;; of this, we don't believe it's necessary to
+                          ;; set `encrypt` to `true` as it used to be
+                          ;; prior to Driver version 6.0.
                           ;;
-                          ;; [1]:
-                          ;; https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-2017
+                          ;; [1]: https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-2017
                           :authentication "SqlPassword"
                           :trustServerCertificate false))]
     ;; returns conn-map and logs on successful connection

--- a/src/tap_mssql/config.clj
+++ b/src/tap_mssql/config.clj
@@ -24,8 +24,7 @@
                    ;; specified. This is for the "correct" way of doing
                    ;; things, where we are validating SSL, but for now,
                    ;; leaving the certificate unverified should work.
-                   (assoc conn-map
-                          ;; Based on the [docs][1], we believe thet
+                   (assoc ;; Based on the [docs][1], we believe thet
                           ;; setting `authentication` to anything but
                           ;; `NotSpecified` (the default) activates SSL
                           ;; for the connection and have verified that by

--- a/src/tap_mssql/core.clj
+++ b/src/tap_mssql/core.clj
@@ -7,7 +7,7 @@
             [tap-mssql.singer.parse :as singer-parse]
             [tap-mssql.singer.messages :as singer-messages]
             [clojure.tools.logging :as log]
-            [clojure.tools.nrepl.server :as nrepl-server]
+            [nrepl.server :as nrepl-server]
             [clojure.tools.cli :as cli]
             [clojure.string :as string]
             [clojure.data.json :as json])

--- a/src/tap_mssql/sync_strategies/full.clj
+++ b/src/tap_mssql/sync_strategies/full.clj
@@ -21,8 +21,7 @@
       (do
         (log/infof "Executing query: %s" (pr-str sql-query))
         (->> (jdbc/query (assoc (config/->conn-map config)
-                                :dbname dbname
-                                :ApplicationIntent "ReadOnly")
+                                :dbname dbname)
                          sql-query
                          {:keywordize? false :identifiers identity})
              first
@@ -129,8 +128,7 @@
                          (singer-messages/write-state-buffered! stream-name))))
                 state
                 (jdbc/reducible-query (assoc (config/->conn-map config)
-                                             :dbname dbname
-                                             :ApplicationIntent "ReadOnly")
+                                             :dbname dbname)
                                       sql-params
                                       common/result-set-opts))
         (update-in ["bookmarks" stream-name] dissoc "last_pk_fetched" "max_pk_values"))))

--- a/src/tap_mssql/sync_strategies/incremental.clj
+++ b/src/tap_mssql/sync_strategies/incremental.clj
@@ -54,8 +54,7 @@
                      (singer-messages/write-state-buffered! stream-name))))
             state
             (jdbc/reducible-query (assoc (config/->conn-map config)
-                                         :dbname dbname
-                                         :ApplicationIntent "ReadOnly")
+                                         :dbname dbname)
                                   sql-params
                                   common/result-set-opts))))
 


### PR DESCRIPTION
# Description of change
Because Full Table is used in Log-Based scenarios, and ChangeTracking (Log-Based Replication for tap-mssql) is generally used with secondary replicas, and mirrors, the current implementation is still not quite there.

The solution without having to deeply introspect the target server's infra somehow, then, is to catch exceptions while checking the connection, dissoc the ApplicationIntent in the event of a failure and retry once.

For posterity, this message can also occur when using ApplicationIntent ReadOnly where a mirror is configured:

```
Connecting to a mirrored SQL Server instance using the ApplicationIntent ReadOnly connection property is not supported.
```

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
Medium at this point, this is take 3, but this solution should be safer.

# Rollback steps
 - revert this branch, bump patch, re-release
