### PR TITLE
Set readonly for query based with fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.7
+  * Apply approaches from 1.6.5 and 1.6.6 to only try `ApplicationIntent=ReadOnly` for query-based connections, and fall-back to not read only if the check fails. [#55](https://github.com/singer-io/tap-mssql/pull/55)
+
 ## 1.6.6
   * Handle cases where `ApplicationIntent=ReadOnly` is not doable for log-based sync's initial full table [#53](https://github.com/singer-io/tap-mssql/pull/53)
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.6.6"
+  "1.6.7"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."

--- a/src/tap_mssql/config.clj
+++ b/src/tap_mssql/config.clj
@@ -9,43 +9,47 @@
       conn-map))
 
 (defn ->conn-map*
-  [config]
-  (let [conn-map (cond-> {:dbtype "sqlserver"
-                          :dbname (or (config "database") "") ;; database is optional - if omitted it is set to an empty string
-                          :host (config "host")
-                          :port (or (config "port") 0) ;; port is optional - if omitted it is set to 0 for a dynamic port
-                          :password (config "password")
-                          :user (config "user")
-                          :ApplicationIntent "ReadOnly"}
-                   (= "true" (config "ssl"))
-                   ;; TODO: The only way I can get a test failure is by
-                   ;; changing the code to say ":trustServerCertificate
-                   ;; false". In which case, truststores need to be
-                   ;; specified. This is for the "correct" way of doing
-                   ;; things, where we are validating SSL, but for now,
-                   ;; leaving the certificate unverified should work.
-                   (assoc ;; Based on the [docs][1], we believe thet
-                          ;; setting `authentication` to anything but
-                          ;; `NotSpecified` (the default) activates SSL
-                          ;; for the connection and have verified that by
-                          ;; setting `trustServerCertificate` to `false`
-                          ;; with `authentication` set to `SqlPassword`
-                          ;; and observing SSL handshake errors. Because
-                          ;; of this, we don't believe it's necessary to
-                          ;; set `encrypt` to `true` as it used to be
-                          ;; prior to Driver version 6.0.
-                          ;;
-                          ;; [1]: https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-2017
-                          :authentication "SqlPassword"
-                          :trustServerCertificate false))]
-    ;; returns conn-map and logs on successful connection
-    (loop [test-conn conn-map
-           retry? true]
-      (if-let [checked-conn (try
-                              (check-connection test-conn)
-                              (catch com.microsoft.sqlserver.jdbc.SQLServerException ex
-                                (when-not retry? (throw ex))))]
-        checked-conn
-        (recur (dissoc test-conn :ApplicationIntent) false)))))
+  ([config]
+   (->conn-map* config false))
+  ([config is-readonly?]
+   (let [conn-map (cond-> {:dbtype "sqlserver"
+                           :dbname (or (config "database") "") ;; database is optional - if omitted it is set to an empty string
+                           :host (config "host")
+                           :port (or (config "port") 0) ;; port is optional - if omitted it is set to 0 for a dynamic port
+                           :password (config "password")
+                           :user (config "user")}
+                    is-readonly?
+                    (assoc :ApplicationIntent "ReadOnly")
+
+                    (= "true" (config "ssl"))
+                    ;; TODO: The only way I can get a test failure is by
+                    ;; changing the code to say ":trustServerCertificate
+                    ;; false". In which case, truststores need to be
+                    ;; specified. This is for the "correct" way of doing
+                    ;; things, where we are validating SSL, but for now,
+                    ;; leaving the certificate unverified should work.
+                    (assoc ;; Based on the [docs][1], we believe thet
+                     ;; setting `authentication` to anything but
+                     ;; `NotSpecified` (the default) activates SSL
+                     ;; for the connection and have verified that by
+                     ;; setting `trustServerCertificate` to `false`
+                     ;; with `authentication` set to `SqlPassword`
+                     ;; and observing SSL handshake errors. Because
+                     ;; of this, we don't believe it's necessary to
+                     ;; set `encrypt` to `true` as it used to be
+                     ;; prior to Driver version 6.0.
+                     ;;
+                     ;; [1]: https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-2017
+                     :authentication "SqlPassword"
+                     :trustServerCertificate false))]
+     ;; returns conn-map and logs on successful connection
+     (loop [test-conn conn-map
+            retry? true]
+       (if-let [checked-conn (try
+                               (check-connection test-conn)
+                               (catch com.microsoft.sqlserver.jdbc.SQLServerException ex
+                                 (when-not retry? (throw ex))))]
+         checked-conn
+         (recur (dissoc test-conn :ApplicationIntent) false))))))
 
 (def ->conn-map (memoize ->conn-map*))

--- a/src/tap_mssql/sync_strategies/full.clj
+++ b/src/tap_mssql/sync_strategies/full.clj
@@ -20,7 +20,7 @@
     (if (not (empty? bookmark-keys))
       (do
         (log/infof "Executing query: %s" (pr-str sql-query))
-        (->> (jdbc/query (assoc (config/->conn-map config)
+        (->> (jdbc/query (assoc (config/->conn-map config true)
                                 :dbname dbname)
                          sql-query
                          {:keywordize? false :identifiers identity})
@@ -127,7 +127,7 @@
                     (->> (singer-bookmarks/update-last-pk-fetched stream-name bookmark-keys acc record)
                          (singer-messages/write-state-buffered! stream-name))))
                 state
-                (jdbc/reducible-query (assoc (config/->conn-map config)
+                (jdbc/reducible-query (assoc (config/->conn-map config true)
                                              :dbname dbname)
                                       sql-params
                                       common/result-set-opts))

--- a/src/tap_mssql/sync_strategies/incremental.clj
+++ b/src/tap_mssql/sync_strategies/incremental.clj
@@ -53,7 +53,7 @@
                 (->> (singer-bookmarks/update-state stream-name replication-key record acc)
                      (singer-messages/write-state-buffered! stream-name))))
             state
-            (jdbc/reducible-query (assoc (config/->conn-map config)
+            (jdbc/reducible-query (assoc (config/->conn-map config true)
                                          :dbname dbname)
                                   sql-params
                                   common/result-set-opts))))

--- a/test/tap_mssql/discover_config_test.clj
+++ b/test/tap_mssql/discover_config_test.clj
@@ -9,7 +9,8 @@
             [tap-mssql.config :as config]
             [tap-mssql.singer.parse :as singer-parse]
             [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
-                                          test-db-config]]))
+                                          test-db-config
+                                          sql-server-exception]]))
 
 (defn get-destroy-database-command
   [database]
@@ -220,16 +221,10 @@
 ;;      (for [expected-stream-name expected-stream-names]
 ;;        (is (contains? discovered-streams expected-stream-name))))))
 
+
 (deftest ^:integration verify-application-intent-only-set-if-check-succeeds
   (is (= "ReadOnly"
          (:ApplicationIntent (config/->conn-map* test-db-config)))))
-
-(defn sql-server-exception []
-  (.newInstance (doto (.getDeclaredConstructor com.microsoft.sqlserver.jdbc.SQLServerException
-                                               (into-array [String Throwable]))
-                  (.setAccessible true))
-                (object-array ["__TEST_BOOM__"
-                               (Exception. "Inner BOOM")])))
 
 (deftest ^:integration verify-application-intent-only-unset-if-check-fails-first-time
   (let [times (atom 0)]

--- a/test/tap_mssql/discover_config_test.clj
+++ b/test/tap_mssql/discover_config_test.clj
@@ -222,8 +222,12 @@
 ;;        (is (contains? discovered-streams expected-stream-name))))))
 
 
-(deftest ^:integration verify-application-intent-only-set-if-check-succeeds
+(deftest ^:integration verify-application-intent-only-set-if-check-succeeds-and-read-only?-is-true
   (is (= "ReadOnly"
+         (:ApplicationIntent (config/->conn-map* test-db-config true)))))
+
+(deftest ^:integration verify-application-intent-not-set-if-check-succeeds-but-read-only?-is-false
+  (is (= nil
          (:ApplicationIntent (config/->conn-map* test-db-config)))))
 
 (deftest ^:integration verify-application-intent-only-unset-if-check-fails-first-time
@@ -234,7 +238,7 @@
                                               (throw (sql-server-exception)))
                                             conn-map)]
      (is (= nil
-            (:ApplicationIntent (config/->conn-map* test-db-config)))))))
+            (:ApplicationIntent (config/->conn-map* test-db-config true)))))))
 
 (deftest ^:integration verify-application-intent-only-unset-if-check-fails-continuously
   (with-redefs [config/check-connection (fn [conn-map]
@@ -242,4 +246,4 @@
     (is (thrown-with-msg?
          com.microsoft.sqlserver.jdbc.SQLServerException
          #"__TEST_BOOM__"
-         (config/->conn-map* test-db-config)))))
+         (config/->conn-map* test-db-config true)))))

--- a/test/tap_mssql/test_utils.clj
+++ b/test/tap_mssql/test_utils.clj
@@ -59,3 +59,10 @@
                 `(let [~(symbol "test-db-config") ~test-db-config]
                    (~fixture-fn (fn [] ~@body) ~(symbol "test-db-config"))))
               test-configs))))
+
+(defn sql-server-exception []
+  (.newInstance (doto (.getDeclaredConstructor com.microsoft.sqlserver.jdbc.SQLServerException
+                                               (into-array [String Throwable]))
+                  (.setAccessible true))
+                (object-array ["__TEST_BOOM__"
+                               (Exception. "Inner BOOM")])))


### PR DESCRIPTION
# Description of change
In log-based syncing situations, the error won't get thrown when the tap calls `check-connection` with readonly metadata, because that is a valid query for `ApplicationIntent="ReadOnly"`. It instead fails when the change tracking tables are queried.

This splits the `config/->conn-map` function into two arities, one of which allows query-based syncs to attempt `ApplicationIntent="ReadOnly"` appropriately, the other allowing log-based to remain unchanged.

Added an integration test that sets up the scenario where the log-based query would throw, and it succeeds.

# QA steps
 - [X] automated tests passing
 - [ ] manual qa steps passing (list below)
     - N/A, went through and manually made the automated test we added fail.
 
# Risks
Medium at this point, this will be round 3 of trying to get this right.

# Rollback steps
 - revert back to 1.6.3, bump patch version, and re-release
