### PR TITLE
add  circleci-user context to the build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ workflows:
   build_and_test:
     jobs:
       - build
+          context: circleci-user
       - tap_tester:
           context: circleci-user
           requires:
@@ -93,6 +94,7 @@ workflows:
                 - master
     jobs:
       - build
+          context: circleci-user
       - tap_tester:
           context: circleci-user
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build:
           context: circleci-user
       - tap_tester:
           context: circleci-user
@@ -93,7 +93,7 @@ workflows:
               only:
                 - master
     jobs:
-      - build
+      - build:
           context: circleci-user
       - tap_tester:
           context: circleci-user


### PR DESCRIPTION
# Description of change
We are not getting the slack webhook from the circleci-user context in the build job of the cirlce workflow. Fix that.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
