### PR TITLE
v1.6.8: Add macro to retry arbitrary code with a readonly db-spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.8
+  * Attempt readonly connections on `jdbc/reducible-query` and `jdbc/query` calls in Full Table and Incremental Syncs [#58](https://github.com/singer-io/tap-mssql/pull/58)
+
 ## 1.6.7
   * Apply approaches from 1.6.5 and 1.6.6 to only try `ApplicationIntent=ReadOnly` for query-based connections, and fall-back to not read only if the check fails. [#55](https://github.com/singer-io/tap-mssql/pull/55)
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.6.7"
+  "1.6.8"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."

--- a/src/tap_mssql/config.clj
+++ b/src/tap_mssql/config.clj
@@ -1,5 +1,5 @@
 (ns tap-mssql.config
-  (:require [tap-mssql.utils :refer [with-read-only]]
+  (:require [tap-mssql.utils :refer [try-read-only]]
             [clojure.tools.logging :as log]
             [clojure.java.jdbc :as jdbc]))
 
@@ -43,7 +43,7 @@
                      :trustServerCertificate false))]
      ;; returns conn-map and logs on successful connection
      (if is-readonly?
-       (with-read-only [test-conn conn-map]
+       (try-read-only [test-conn conn-map]
          (check-connection test-conn))
        (check-connection conn-map)))))
 

--- a/src/tap_mssql/sync_strategies/full.clj
+++ b/src/tap_mssql/sync_strategies/full.clj
@@ -1,7 +1,7 @@
 (ns tap-mssql.sync-strategies.full
   (:refer-clojure :exclude [sync])
   (:require [tap-mssql.config :as config]
-            [tap-mssql.utils :refer [with-read-only]]
+            [tap-mssql.utils :refer [try-read-only]]
             [tap-mssql.singer.fields :as singer-fields]
             [tap-mssql.singer.bookmarks :as singer-bookmarks]
             [tap-mssql.singer.messages :as singer-messages]
@@ -21,7 +21,7 @@
     (if (not (empty? bookmark-keys))
       (do
         (log/infof "Executing query: %s" (pr-str sql-query))
-        (->> (with-read-only [conn-map (assoc (config/->conn-map config)
+        (->> (try-read-only [conn-map (assoc (config/->conn-map config)
                                               :dbname dbname)]
                (jdbc/query conn-map
                            sql-query
@@ -120,7 +120,7 @@
         schema-name   (get-in catalog ["streams" stream-name "metadata" "schema-name"])
         sql-params    (build-sync-query stream-name schema-name table-name record-keys state)]
     (log/infof "Executing query: %s" (pr-str sql-params))
-    (-> (with-read-only [conn-map (assoc (config/->conn-map config)
+    (-> (try-read-only [conn-map (assoc (config/->conn-map config)
                                          :dbname dbname)]
           (reduce (fn [acc result]
                     (let [record (select-keys result record-keys)]

--- a/src/tap_mssql/sync_strategies/full.clj
+++ b/src/tap_mssql/sync_strategies/full.clj
@@ -1,6 +1,7 @@
 (ns tap-mssql.sync-strategies.full
   (:refer-clojure :exclude [sync])
   (:require [tap-mssql.config :as config]
+            [tap-mssql.utils :refer [with-read-only]]
             [tap-mssql.singer.fields :as singer-fields]
             [tap-mssql.singer.bookmarks :as singer-bookmarks]
             [tap-mssql.singer.messages :as singer-messages]
@@ -20,10 +21,11 @@
     (if (not (empty? bookmark-keys))
       (do
         (log/infof "Executing query: %s" (pr-str sql-query))
-        (->> (jdbc/query (assoc (config/->conn-map config true)
-                                :dbname dbname)
-                         sql-query
-                         {:keywordize? false :identifiers identity})
+        (->> (with-read-only [conn-map (assoc (config/->conn-map config)
+                                              :dbname dbname)]
+               (jdbc/query conn-map
+                           sql-query
+                           {:keywordize? false :identifiers identity}))
              first
              (assoc-in state ["bookmarks" stream-name "max_pk_values"])))
       state)))
@@ -118,19 +120,20 @@
         schema-name   (get-in catalog ["streams" stream-name "metadata" "schema-name"])
         sql-params    (build-sync-query stream-name schema-name table-name record-keys state)]
     (log/infof "Executing query: %s" (pr-str sql-params))
-    (-> (reduce (fn [acc result]
-                  (let [record (select-keys result record-keys)]
-                    (singer-messages/write-record! stream-name
-                                                   state
-                                                   record
-                                                   catalog)
-                    (->> (singer-bookmarks/update-last-pk-fetched stream-name bookmark-keys acc record)
-                         (singer-messages/write-state-buffered! stream-name))))
-                state
-                (jdbc/reducible-query (assoc (config/->conn-map config true)
-                                             :dbname dbname)
-                                      sql-params
-                                      common/result-set-opts))
+    (-> (with-read-only [conn-map (assoc (config/->conn-map config)
+                                         :dbname dbname)]
+          (reduce (fn [acc result]
+                    (let [record (select-keys result record-keys)]
+                      (singer-messages/write-record! stream-name
+                                                     state
+                                                     record
+                                                     catalog)
+                      (->> (singer-bookmarks/update-last-pk-fetched stream-name bookmark-keys acc record)
+                           (singer-messages/write-state-buffered! stream-name))))
+                  state
+                  (jdbc/reducible-query conn-map
+                                        sql-params
+                                        common/result-set-opts)))
         (update-in ["bookmarks" stream-name] dissoc "last_pk_fetched" "max_pk_values"))))
 
 (defn sync!

--- a/src/tap_mssql/utils.clj
+++ b/src/tap_mssql/utils.clj
@@ -1,15 +1,19 @@
 (ns tap-mssql.utils)
 
-;; TODO: This needs to be a binding situation, like `let`
-;; E.g., `(try-with-readonly [my-conn (get-a-conn-map)] (do-thing-with-readonly-or-not-conn-map my-conn)`
-;; ---- result of this would be that it always trys with readonly then without, which could be rough in situations where it's not available
 (defmacro with-read-only
   "
   Note: This macro is structured similar to if-let.
 
   Tries macro body with ApplicationIntent set, then without (if first
   fails). The db-spec used is defined in the binding supplied to this
-  macro."
+  macro.
+
+  Example:
+
+  (with-read-only [a-db-spec-binding (config/->conn-map config)]
+    (jdbc/query a-db-spec-binding
+                \"SELECT 'this should work with read-only, if possible'\"))
+  "
   [bindings & body]
   (assert (vector? bindings) "try-with-read-only requires a vector for its binding.")
   (assert (= 2 (count bindings)) "try-with-read-only requires exactly 2 forms in binding vector")

--- a/src/tap_mssql/utils.clj
+++ b/src/tap_mssql/utils.clj
@@ -1,6 +1,6 @@
 (ns tap-mssql.utils)
 
-(defmacro with-read-only
+(defmacro try-read-only
   "
   Note: This macro is structured similar to if-let.
 
@@ -10,20 +10,20 @@
 
   Example:
 
-  (with-read-only [a-db-spec-binding (config/->conn-map config)]
+  (try-read-only [a-db-spec-binding (config/->conn-map config)]
     (jdbc/query a-db-spec-binding
                 \"SELECT 'this should work with read-only, if possible'\"))
   "
   [bindings & body]
-  (assert (vector? bindings) "try-with-read-only requires a vector for its binding.")
-  (assert (= 2 (count bindings)) "try-with-read-only requires exactly 2 forms in binding vector")
+  (assert (vector? bindings) "try-read-only requires a vector for its binding.")
+  (assert (= 2 (count bindings)) "try-read-only requires exactly 2 forms in binding vector")
   (let [inner-name (bindings 0)
         binding-val (bindings 1)]
     `(let [db-spec-initial# ~binding-val]
        (loop [~inner-name (assoc db-spec-initial# :ApplicationIntent "ReadOnly")
               should-retry# true]
          (if-let [result# (try
-                           (do ~@body)
+                           ~@body
                            (catch com.microsoft.sqlserver.jdbc.SQLServerException ex#
                              (when-not should-retry# (throw ex#))))]
            result#

--- a/src/tap_mssql/utils.clj
+++ b/src/tap_mssql/utils.clj
@@ -1,0 +1,26 @@
+(ns tap-mssql.utils)
+
+;; TODO: This needs to be a binding situation, like `let`
+;; E.g., `(try-with-readonly [my-conn (get-a-conn-map)] (do-thing-with-readonly-or-not-conn-map my-conn)`
+;; ---- result of this would be that it always trys with readonly then without, which could be rough in situations where it's not available
+(defmacro with-read-only
+  "
+  Note: This macro is structured similar to if-let.
+
+  Tries macro body with ApplicationIntent set, then without (if first
+  fails). The db-spec used is defined in the binding supplied to this
+  macro."
+  [bindings & body]
+  (assert (vector? bindings) "try-with-read-only requires a vector for its binding.")
+  (assert (= 2 (count bindings)) "try-with-read-only requires exactly 2 forms in binding vector")
+  (let [inner-name (bindings 0)
+        binding-val (bindings 1)]
+    `(let [db-spec-initial# ~binding-val]
+       (loop [~inner-name (assoc db-spec-initial# :ApplicationIntent "ReadOnly")
+              should-retry# true]
+         (if-let [result# (try
+                           (do ~@body)
+                           (catch com.microsoft.sqlserver.jdbc.SQLServerException ex#
+                             (when-not should-retry# (throw ex#))))]
+           result#
+           (recur (dissoc ~inner-name :ApplicationIntent) false))))))

--- a/test/tap_mssql/try_read_only_utils_test.clj
+++ b/test/tap_mssql/try_read_only_utils_test.clj
@@ -1,0 +1,28 @@
+(ns tap-mssql.try-read-only-utils-test
+  (:require [tap-mssql.utils :refer [try-read-only]]
+            [clojure.test :refer :all]
+            [tap-mssql.test-utils :refer [sql-server-exception]])
+  (:import [java.sql Date]))
+
+
+(deftest ^:integration verify-application-intent-only-set-if-body-succeeds
+  (is (= "ReadOnly"
+         (:ApplicationIntent (try-read-only [db-spec {}]
+                               db-spec)))))
+
+(deftest ^:integration verify-application-intent-only-unset-if-body-fails-first-time
+  (let [times (atom 0)]
+    (is (= nil
+           (:ApplicationIntent
+            (try-read-only [db-spec {:ApplicationIntent "ReadOnly"}]
+                           (when (= 0 @times)
+                             (swap! times inc)
+                             (throw (sql-server-exception)))
+                           db-spec))))))
+
+(deftest ^:integration verify-application-intent-only-unset-if-body-fails-continuously
+  (is (thrown-with-msg?
+       com.microsoft.sqlserver.jdbc.SQLServerException
+       #"__TEST_BOOM__"
+       (try-read-only [db-spec {:ApplicationIntent "ReadOnly"}]
+                      (throw (sql-server-exception))))))


### PR DESCRIPTION
# Description of change
In the epic read-only ApplicationIntent saga, it appears that the query being executed by the connection check doesn't always throw on the first time it's called. In this case, the read-only db-spec gets cached.

Additionally, the forms that throw are more complicated than just a `config/->conn-map` call, they are actual queries and/or JDBC query wrappers (specifically `jdbc/reducible-query`).

So, given these requirements, this PR adds an `if-let` style macro that takes a singular binding of a db-spec, a body of command(s) to run with that db-spec binding, and retries the body if it fails with `ApplicationIntent=ReadOnly` set.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
     - Successfully synced initial full table of a log-based replication for a database that was having the issue described above.
 
# Risks
It's currently broken for this edge case, and is manually tested against it. So, if tests pass, I am very confident in this change's ability to not break existing connections.

# Rollback steps
 - revert this branch
