### PR TITLE
Bump to v1.6.10, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.10
+  * Update `nrepl` server binding from `0.0.0.0` to `127.0.0.1` [#62](https://github.com/stitchdata/tap-mssql/pull/62)
+
 ## 1.6.9
   * Quote the `ORDER BY` columns in incremental queries [#59](https://github.com/singer-io/tap-mssql/pull/59)
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.6.9"
+  "1.6.10"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."


### PR DESCRIPTION
# Description of change
Version bump for #62 

## 1.6.10
*  Update `nrepl` server binding from `0.0.0.0` to `127.0.0.1` [#62](https://github.com/stitchdata/tap-mssql/pull/62)

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
