### PR TITLE
bump numpy dep for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             source tap-mssql.env
             lein deps
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            pip install numpy==1.16.4
+            pip install numpy==1.21.2
             run-test --tap=/root/project/bin/tap-mssql \
                      tests
       - slack/notify-on-failure:


### PR DESCRIPTION
# Description of change
Bump numpy now that we are running python 3.9.6

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
