### PR TITLE
Update README with `mssql-cli` install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ $ bin/test
 
 Note: It also depends on the `mssql-cli` tool being installed in order to use the `connect` option.
 
+To install `mssql-cli`:
+- create a virtualenv
+- source your new virtualenv
+- `pip install mssql-cli`
+
+Before running `bin/test-db connect`, just make sure your virtualenv is sourced.
+
 ```
 Example:
 $ bin/test-db start


### PR DESCRIPTION
# Description of change
This PR adds instructions to install the `mssql-cli` tool. These instructions should work for most platforms.

The main reason I installed it via `pip` was because there's no official `apt` package for Ubuntu 20.04.

# QA steps
I ran through these steps myself.

# Risks
- Low since this is just for local testing

# Rollback steps
- revert this branch