### PR TITLE
Fix/pin circleci mssql image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       - image: clojure:lein-2.5.3
-      - image: mcr.microsoft.com/mssql/server:2017-CU27-ubuntu-16.04
+      - image: mcr.microsoft.com/mssql/server:2017-CU25-ubuntu-16.04
         environment:
           ACCEPT_EULA: Y
           SA_PASSWORD: Password1!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       - image: clojure:lein-2.5.3
-      - image: mcr.microsoft.com/mssql/server:2017-latest
+      - image: mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-16.04
         environment:
           ACCEPT_EULA: Y
           SA_PASSWORD: Password1!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       - image: clojure:lein-2.5.3
-      - image: mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-16.04
+      - image: mcr.microsoft.com/mssql/server:2017-CU27-ubuntu-16.04
         environment:
           ACCEPT_EULA: Y
           SA_PASSWORD: Password1!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
   tap_tester:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-clj
-      - image: mcr.microsoft.com/mssql/server:2017-latest
+      - image: mcr.microsoft.com/mssql/server:2017-CU25-ubuntu-16.04
         environment:
           ACCEPT_EULA: Y
           SA_PASSWORD: Password1!


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-15619
Our theory on this card is that certain image versions of mssql server result in the table MSchange_tracking_history being discovered.
Therefore, we pinned to a certain version of mssql that we saw has historically not discovered the table.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
very very low, this only affects the testing environment and we saw it pass in tap-tester
# Rollback steps
 - revert this branch
