### PR TITLE
Add get-last-pk-fetched to logical.clj for rowversion bookmarks

### DIFF
--- a/src/tap_mssql/sync_strategies/logical.clj
+++ b/src/tap_mssql/sync_strategies/logical.clj
@@ -152,7 +152,7 @@
                                                                                stream-name
                                                                                "metadata"
                                                                                "table-key-properties"])))
-        primary-key-bookmarks (get-last-pk-fetched [stream-name state])
+        primary-key-bookmarks (get-last-pk-fetched stream-name state)
         current-log-version   (get-in state ["bookmarks" stream-name "current_log_version"])
         _                     (log/infof "Syncing log-based stream at version: %d" current-log-version)
         record-keys           (map common/sanitize-names (clojure.set/difference (set (singer-fields/get-selected-fields catalog stream-name))


### PR DESCRIPTION
# Description of change
Add logic to properly handle byte array bookmarks for interrupted logical replication.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
   - Tested with affected user's integration and confirmed successfully resumed logical replication.
 
# Risks

# Rollback steps
 - revert this branch
