### PR TITLE
Version 1.6.11: Update log4j using singer-clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.12
+  * Update singer-clojure and logging dependencies [#84](https://github.com/stitchdata/tap-mssql/pull/84)
+
 ## 1.6.11
   * Fix RowVersion states for logical syncs [#76](https://github.com/stitchdata/tap-mssql/pull/76)
 

--- a/project.clj
+++ b/project.clj
@@ -13,11 +13,10 @@
                  [com.microsoft.sqlserver/mssql-jdbc "7.2.1.jre8"]
 
                  ;; logging
-                 [org.clojure/tools.logging "0.3.1"]
-                 [log4j "1.2.17" :exclusions [javax.mail/mail
-                                              javax.jms/jms
-                                              com.sun.jdmk/jmxtools
-                                              com.sun.jmx/jmxri]]
+                 [org.clojure/tools.logging "1.2.4"]
+
+                 ;; singer-clojure
+                 [singer-clojure "1.1.8"]
 
                  ;; repl
                  [nrepl "0.6.0"] ;; For Lein 2.9.X

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."
-            :url "https://www.gnu.org/licenses/agpl-3.0.en.html"}
+            :url  "https://www.gnu.org/licenses/agpl-3.0.en.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.cli "0.4.1"]
                  [org.clojure/data.json "0.2.6"]
@@ -12,14 +12,11 @@
                  [org.clojure/java.jdbc "0.7.9"]
                  [com.microsoft.sqlserver/mssql-jdbc "7.2.1.jre8"]
 
-                 ;; logging
-                 [org.clojure/tools.logging "1.2.4"]
-
                  ;; singer-clojure
                  [singer-clojure "1.1.8"]
 
                  ;; repl
-                 [nrepl "0.6.0"] ;; For Lein 2.9.X
+                 [nrepl "0.6.0"]              ;; For Lein 2.9.X
                  [cider/cider-nrepl "0.25.4"] ;; For cider-emacs 0.26.1
 
                  ;; test
@@ -28,4 +25,5 @@
   :plugins [[lein-pprint "1.2.0"]]
   :main tap-mssql.core
   :profiles {:uberjar {:aot [tap-mssql.core]}
-             :system {:java-cmd "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"}})
+             :system  {:java-cmd "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"}}
+  :manifest {"Multi-Release" "true"})

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.6.11"
+  "1.6.12"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."

--- a/src/tap_mssql/core.clj
+++ b/src/tap_mssql/core.clj
@@ -178,7 +178,7 @@
           (System/exit 0)))
 
       (catch Throwable ex
-        (singer-log/log-fatal))
+        (singer-log/log-fatal "Fatal Error Occured" ex))
       (finally
         ;; If we somehow skip the catch block, we need to always at least exit if not --repl
         (maybe-stop-nrepl-server args the-nrepl-server)

--- a/src/tap_mssql/core.clj
+++ b/src/tap_mssql/core.clj
@@ -7,6 +7,7 @@
             [tap-mssql.singer.parse :as singer-parse]
             [tap-mssql.singer.messages :as singer-messages]
             [clojure.tools.logging :as log]
+            [singer-clojure.log :as singer-log]
             [nrepl.server :as nrepl-server]
             [clojure.tools.cli :as cli]
             [clojure.string :as string]
@@ -177,10 +178,7 @@
           (System/exit 0)))
 
       (catch Throwable ex
-        (def ex ex)
-        (.printStackTrace ex)
-        (dorun (map #(log/fatal %) (string/split (or (.getMessage ex)
-                                                     (str ex)) #"\n"))))
+        (singer-log/log-fatal))
       (finally
         ;; If we somehow skip the catch block, we need to always at least exit if not --repl
         (maybe-stop-nrepl-server args the-nrepl-server)

--- a/tests/test_mssql_drop_multiple_tables.py
+++ b/tests/test_mssql_drop_multiple_tables.py
@@ -165,7 +165,7 @@ class MssqlDropTables(BaseTapTest):
 
         # verify check exit codes
         exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        self.assertEqual(exit_status['discovery_error_message'], 'Empty Catalog: did not discover any streams')
+        self.assertEqual(exit_status['discovery_error_message'], '[main] tap-mssql.core - Fatal Error Occured - Empty Catalog: did not discover any streams')
 
         # Assert that expected tables are still selected
         for stream in self.expected_sync_streams():

--- a/tests/test_mssql_log_based_no_pk.py
+++ b/tests/test_mssql_log_based_no_pk.py
@@ -126,4 +126,4 @@ class LogBasedNoPkTest(BaseTapTest):
         exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
 
         # validate the exit status message on table which does not have pk
-        self.assertEqual(exit_status['tap_error_message'], 'Cannot sync stream: log_based_no_pk_dbo_int_data_no_pk using log-based replication. Change Tracking is not enabled for table: int_data_no_pk')
+        self.assertEqual(exit_status['tap_error_message'], '[main] tap-mssql.core - Fatal Error Occured - Cannot sync stream: log_based_no_pk_dbo_int_data_no_pk using log-based replication. Change Tracking is not enabled for table: int_data_no_pk')


### PR DESCRIPTION
# Description of change
Updating log4j using singer-clojure due to vulnerability in [CVE-2020-9493](https://github.com/advisories/GHSA-prp9-9gxw-38j8) for TDL-21424

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
- Low

# Rollback steps
 - revert this branch
