### PR TITLE
Remove `maxLength` from the catalog

### DIFF
--- a/src/tap_mssql/catalog.clj
+++ b/src/tap_mssql/catalog.clj
@@ -164,14 +164,10 @@
                                                "format" "date-time"}
                            "datetime2"        {"type"   ["string"]
                                                "format" "date-time"}
-                           "char"             {"type"      ["string"]
-                                               "maxLength" (:column_size column)}
-                           "nchar"            {"type"      ["string"]
-                                               "maxLength" (:column_size column)}
-                           "varchar"          {"type"      ["string"]
-                                               "maxLength" (:column_size column)}
-                           "nvarchar"         {"type"      ["string"]
-                                               "maxLength" (:column_size column)}
+                           "char"             {"type"      ["string"]}
+                           "nchar"            {"type"      ["string"]}
+                           "varchar"          {"type"      ["string"]}
+                           "nvarchar"         {"type"      ["string"]}
                            "binary"           {"type"      ["string"]}
                            "varbinary"        {"type"      ["string"]}
                            "uniqueidentifier" {"type"    ["string"]

--- a/test/tap_mssql/discover_populated_catalog_datatyping_test.clj
+++ b/test/tap_mssql/discover_populated_catalog_datatyping_test.clj
@@ -199,32 +199,25 @@
                  ["streams" "datatyping_dbo_approximate_numerics" "schema" "properties" "real"]))))
 
 (deftest ^:integration verify-unicode-strings
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_unicode_character_strings" "schema" "properties" "nchar"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_unicode_character_strings" "schema" "properties" "nchar_1"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 4000}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_unicode_character_strings" "schema" "properties" "nchar_4000"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_unicode_character_strings" "schema" "properties" "nvarchar"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_unicode_character_strings" "schema" "properties" "nvarchar_1"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 4000}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_unicode_character_strings" "schema" "properties" "nvarchar_4000"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 2147483647}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_unicode_character_strings" "schema" "properties" "nvarchar_max"]))))
 
@@ -314,32 +307,25 @@
                  ["streams" "datatyping_dbo_exact_numerics" "schema" "properties" "numeric_38_22"]))))
 
 (deftest ^:integration verify-character-strings
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_character_strings" "schema" "properties" "char"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_character_strings" "schema" "properties" "char_one"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 8000}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_character_strings" "schema" "properties" "char_8000"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_character_strings" "schema" "properties" "varchar"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 1}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_character_strings" "schema" "properties" "varchar_one"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 8000}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_character_strings" "schema" "properties" "varchar_8000"])))
-  (is (= {"type" ["string" "null"]
-          "maxLength" 2147483647}
+  (is (= {"type" ["string" "null"]}
          (get-in (catalog/discover test-db-config)
                  ["streams" "datatyping_dbo_character_strings" "schema" "properties" "varchar_max"]))))
 

--- a/tests/spec.py
+++ b/tests/spec.py
@@ -49,9 +49,9 @@ class TapSpec:
                     "type": ["number", "null"],
                     'maximum': 10 ** 18, 'exclusiveMinimum': True,
                     'minimum': -10 ** 18, 'exclusiveMaximum': True},
-        "char": {"type": ["string", "null"], "maxLength": 2, "minLength": 2},  # TODO this is just for char(2)
-        "varchar": {"type": ["string", "null"], "maxLength": 8000, "minLength": 0},  # TODO this is just for varchar(800)
-        "nvarchar": {"type": ["string", "null"], "maxLength": 8000, "minLength": 0},  # TODO this is just for nvarchar(800)
+        "char": {"type": ["string", "null"], "minLength": 2},  # TODO this is just for char(2)
+        "varchar": {"type": ["string", "null"], "minLength": 0},  # TODO this is just for varchar(800)
+        "nvarchar": {"type": ["string", "null"], "minLength": 0},  # TODO this is just for nvarchar(800)
         "date": {"type": ["string", "null"], 'format': 'date-time'},
         "datetime": {"type": ["string", "null"], 'format': 'date-time'},
         "time": {"type": ["string", "null"]},

--- a/tests/test_full_table_interrupted.py
+++ b/tests/test_full_table_interrupted.py
@@ -78,19 +78,16 @@ class FullTableInterrupted(BaseTapTest):
                     'minimum': -2147483648},
                 'varchar_8000': {
                     'type': ['string', 'null'],
-                    'maxLength': 8000,
                     'inclusion': 'available',
                     'selected': True},
                     # 'minLength': 0},
                 'varchar_5': {
                     'type': ['string', 'null'],
-                    'maxLength': 5,
                     'inclusion': 'available',
                     'selected': True},
                     # 'minLength': 0},
                 'varchar_max': {
                     'type': ['string', 'null'],
-                    'maxLength': 2147483647,
                     'inclusion': 'available',
                     'selected': True}}}
                     # 'minLength': 0}}}

--- a/tests/test_sync_full_names.py
+++ b/tests/test_sync_full_names.py
@@ -63,7 +63,6 @@ class SyncTestNameFull(BaseTapTest):
             'properties': {
                 char_name: {
                     'type': ['string', 'null'],
-                    'maxLength': 2,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 2},
@@ -94,18 +93,15 @@ class SyncTestNameFull(BaseTapTest):
                     'minimum': -2147483648},
                 'varchar_8000': {
                     'type': ['string', 'null'],
-                    'maxLength': 8000,
                     'inclusion': 'available',
                     'selected': True},  # 'minLength': 0},
                 varchar_name: {
                     'type': ['string', 'null'],
-                    'maxLength': 5,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 0},
                 'varchar_max': {
                     'type': ['string', 'null'],
-                    'maxLength': 2147483647,
                     'inclusion': 'available',
                     'selected': True}}}
                 # 'minLength': 0}}}
@@ -124,7 +120,6 @@ class SyncTestNameFull(BaseTapTest):
             'properties': {
                 nchar_name: {
                     'type': ['string', 'null'],
-                    'maxLength': 8,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 8},  # length is based on bytes, not characters
@@ -150,7 +145,6 @@ class SyncTestNameFull(BaseTapTest):
             'properties': {
                 'nvarchar_max': {
                     'type': ['string', 'null'],
-                    'maxLength': 2147483647,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 0},
@@ -162,13 +156,11 @@ class SyncTestNameFull(BaseTapTest):
                     'minimum': -2147483648},
                 'nvarchar_4000': {
                     'type': ['string', 'null'],
-                    'maxLength': 4000,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 0},
                 nvarchar_name: {
                     'type': ['string', 'null'],
-                    'maxLength': 5,
                     'inclusion': 'available',
                     'selected': True}}}
                 # 'minLength': 0}}}

--- a/tests/test_sync_full_pks.py
+++ b/tests/test_sync_full_pks.py
@@ -102,12 +102,10 @@ class SyncIntFull(BaseTapTest):
                         'minimum': -2147483648},
                     'first_name': {
                         'type': ['string'],
-                        'maxLength': 256,
                         'inclusion': 'automatic',
                         'selected': True},  # , 'minLength': 0},
                     'last_name': {
                         'type': ['string'],
-                        'maxLength': 256,
                         'inclusion': 'automatic',
                         'selected': True}}}  # 'minLength': 0}}}
         }

--- a/tests/test_sync_full_strings.py
+++ b/tests/test_sync_full_strings.py
@@ -49,7 +49,6 @@ class SyncTestStringFull(BaseTapTest):
             'properties': {
                 'char_2': {
                     'type': ['string', 'null'],
-                    'maxLength': 2,
                     'inclusion': 'available',
                     'selected': True},
                     # 'minLength': 2},
@@ -80,19 +79,16 @@ class SyncTestStringFull(BaseTapTest):
                     'minimum': -2147483648},
                 'varchar_8000': {
                     'type': ['string', 'null'],
-                    'maxLength': 8000,
                     'inclusion': 'available',
                     'selected': True},
                     # 'minLength': 0},
                 'varchar_5': {
                     'type': ['string', 'null'],
-                    'maxLength': 5,
                     'inclusion': 'available',
                     'selected': True},
                     # 'minLength': 0},
                 'varchar_max': {
                     'type': ['string', 'null'],
-                    'maxLength': 2147483647,
                     'inclusion': 'available',
                     'selected': True}}}
                     # 'minLength': 0}}}
@@ -112,7 +108,6 @@ class SyncTestStringFull(BaseTapTest):
             'properties': {
                 'nchar_8': {
                     'type': ['string', 'null'],
-                    'maxLength': 8,
                     'inclusion': 'available',
                     'selected': True},
                     # 'minLength': 8},  # length is based on bytes, not characters
@@ -149,7 +144,6 @@ class SyncTestStringFull(BaseTapTest):
             'properties': {
                 'nvarchar_max': {
                     'type': ['string', 'null'],
-                    'maxLength': 2147483647,
                     'inclusion': 'available',
                     'selected': True},
                     # 'minLength': 0},
@@ -161,13 +155,11 @@ class SyncTestStringFull(BaseTapTest):
                     'minimum': -2147483648},
                 'nvarchar_4000': {
                     'type': ['string', 'null'],
-                    'maxLength': 4000,
                     'inclusion': 'available',
                     'selected': True},
                     # 'minLength': 0},
                 'nvarchar_5': {
                     'type': ['string', 'null'],
-                    'maxLength': 5,
                     'inclusion': 'available',
                     'selected': True}}}
                     # 'minLength': 0}}}

--- a/tests/test_sync_incremental_pks.py
+++ b/tests/test_sync_incremental_pks.py
@@ -104,12 +104,10 @@ class SyncPkIncremental(BaseTapTest):
                         'minimum': -2147483648},
                     'first_name': {
                         'type': ['string'],
-                        'maxLength': 256,
                         'inclusion': 'automatic',
                         'selected': True},  # 'minLength': 0},
                     'last_name': {
                         'type': ['string'],
-                        'maxLength': 256,
                         'inclusion': 'automatic',
                         'selected': True}  # 'minLength': 0},(1, 4, 2, 5)
                     }}

--- a/tests/test_sync_logical_names.py
+++ b/tests/test_sync_logical_names.py
@@ -67,7 +67,6 @@ class SyncNameLogical(BaseTapTest):
             'properties': {
                 CHAR_NAME: {
                     'type': ['string', 'null'],
-                    'maxLength': 2,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 2},
@@ -98,18 +97,15 @@ class SyncNameLogical(BaseTapTest):
                     'minimum': -2147483648},
                 'varchar_8000': {
                     'type': ['string', 'null'],
-                    'maxLength': 8000,
                     'inclusion': 'available',
                     'selected': True},  # 'minLength': 0},
                 VARCHAR_NAME: {
                     'type': ['string', 'null'],
-                    'maxLength': 5,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 0},
                 'varchar_max': {
                     'type': ['string', 'null'],
-                    'maxLength': 2147483647,
                     'inclusion': 'available',
                     'selected': True},
                 "_sdc_deleted_at": {'format': 'date-time', 'type': ['string', 'null']}}}
@@ -128,7 +124,6 @@ class SyncNameLogical(BaseTapTest):
             'properties': {
                 NCHAR_NAME: {
                     'type': ['string', 'null'],
-                    'maxLength': 8,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 8},  # length is based on bytes, not characters
@@ -154,7 +149,6 @@ class SyncNameLogical(BaseTapTest):
             'properties': {
                 'nvarchar_max': {
                     'type': ['string', 'null'],
-                    'maxLength': 2147483647,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 0},
@@ -166,13 +160,11 @@ class SyncNameLogical(BaseTapTest):
                     'minimum': -2147483648},
                 'nvarchar_4000': {
                     'type': ['string', 'null'],
-                    'maxLength': 4000,
                     'inclusion': 'available',
                     'selected': True},
                 # 'minLength': 0},
                 NVARCHAR_NAME: {
                     'type': ['string', 'null'],
-                    'maxLength': 5,
                     'inclusion': 'available',
                     'selected': True},
                 "_sdc_deleted_at": {'format': 'date-time', 'type': ['string', 'null']}}}

--- a/tests/test_sync_logical_pks.py
+++ b/tests/test_sync_logical_pks.py
@@ -106,12 +106,10 @@ class SyncPkLogical(BaseTapTest):
                         'minimum': -2147483648},
                     'first_name': {
                         'type': ['string'],
-                        'maxLength': 256,
                         'inclusion': 'automatic',
                         'selected': True},  # 'minLength': 0},
                     'last_name': {
                         'type': ['string'],
-                        'maxLength': 256,
                         'inclusion': 'automatic',
                         'selected': True},  # 'minLength': 0},(1, 4, 2, 5)
                     "_sdc_deleted_at": {'format': 'date-time', 'type': ['string', 'null']}}}


### PR DESCRIPTION
# Description of change
This PR removes `maxLength` from the JSON schema.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
- Low. Schema validation can fail when we include these values, but it's seems to be stricter than MSSQL is. There's no value in the tap complaining some value looks wrong when the database says the same thing
# Rollback steps
 - revert this branch
