### PR TITLE
Bump to v1.7.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.0
+  * Remove `maxLength` from the catalog [#88](https://github.com/singer-io/tap-mssql/pull/88)
+
 ## 1.6.13
   * Removes rowversion and replication keys as valid interruptible bookmarks for logical replication, ensuring the use of a Primary Key
   * Adds additional check for valid Primary Key before beginning logical replication rather than after completing initial historical replication

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject tap-mssql
-  "1.6.13"
+  "1.7.0"
   :description "Singer.io tap for extracting data from a Microsft SQL Server "
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."


### PR DESCRIPTION
# Description of change
This is the version bump for #88 
# QA steps
See #88  
# Risks
See #88 
# Rollback steps
 - revert #88 and bump the version
