### PR TITLE
Bump org.clojure/clojure to 1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.1
   * Update singer-clojure to 1.2.1 (log4j CVE fixes) [#94](https://github.com/singer-io/tap-mssql/pull/94)
+  * Bump org.clojure/clojure to 1.12.5 [#95](https://github.com/singer-io/tap-mssql/pull/95)
 
 ## 1.8.0
   * Retry logic for the Deadlock error [#91](https://github.com/singer-io/tap-mssql/pull/91)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.8.1
   * Update singer-clojure to 1.2.1 (log4j CVE fixes) [#94](https://github.com/singer-io/tap-mssql/pull/94)
-  * Bump org.clojure/clojure to 1.12.5 [#95](https://github.com/singer-io/tap-mssql/pull/95)
+  * Bump org.clojure/clojure to 1.11.2 [#95](https://github.com/singer-io/tap-mssql/pull/95)
 
 ## 1.8.0
   * Retry logic for the Deadlock error [#91](https://github.com/singer-io/tap-mssql/pull/91)

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."
             :url  "https://www.gnu.org/licenses/agpl-3.0.en.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
                  [org.clojure/tools.cli "0.4.1"]
                  [org.clojure/data.json "0.2.6"]
 

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/stitchdata/tap-mssql"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."
             :url  "https://www.gnu.org/licenses/agpl-3.0.en.html"}
-  :dependencies [[org.clojure/clojure "1.12.5"]
+  :dependencies [[org.clojure/clojure "1.11.2"]
                  [org.clojure/tools.cli "0.4.1"]
                  [org.clojure/data.json "0.2.6"]
 

--- a/test/tap_mssql/sync_full_table_test.clj
+++ b/test/tap_mssql/sync_full_table_test.clj
@@ -1,5 +1,4 @@
 (ns tap-mssql.sync-full-table-test
-  (:import  [microsoft.sql.DateTimeOffset])
   (:require [tap-mssql.catalog :as catalog]
             [tap-mssql.config :as config]
             [clojure.test :refer [is deftest]]
@@ -12,7 +11,8 @@
             [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
-                                          with-matrix-assertions]]))
+                                          with-matrix-assertions]])
+  (:import [microsoft.sql.DateTimeOffset]))
 
 (defn get-destroy-database-command
   [database]

--- a/test/tap_mssql/sync_full_table_test.clj
+++ b/test/tap_mssql/sync_full_table_test.clj
@@ -12,7 +12,7 @@
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]])
-  (:import [microsoft.sql.DateTimeOffset]))
+  (:import [microsoft.sql DateTimeOffset]))
 
 (defn get-destroy-database-command
   [database]

--- a/test/tap_mssql/sync_incremental_test.clj
+++ b/test/tap_mssql/sync_incremental_test.clj
@@ -11,7 +11,7 @@
                                           test-db-config
                                           test-db-configs
                                           with-matrix-assertions]])
-  (:import [microsoft.sql.DateTimeOffset]))
+  (:import [microsoft.sql DateTimeOffset]))
 
 (defn get-destroy-database-command
   [database]

--- a/test/tap_mssql/sync_incremental_test.clj
+++ b/test/tap_mssql/sync_incremental_test.clj
@@ -1,5 +1,4 @@
 (ns tap-mssql.sync-incremental-test
-  (:import  [microsoft.sql.DateTimeOffset])
   (:require [tap-mssql.catalog :as catalog]
             [tap-mssql.config :as config]
             [clojure.test :refer [is deftest]]
@@ -11,7 +10,8 @@
             [tap-mssql.test-utils :refer [with-out-and-err-to-dev-null
                                           test-db-config
                                           test-db-configs
-                                          with-matrix-assertions]]))
+                                          with-matrix-assertions]])
+  (:import [microsoft.sql.DateTimeOffset]))
 
 (defn get-destroy-database-command
   [database]


### PR DESCRIPTION
# Description of change
Bump org.clojure/clojure to 1.11.2

Fix cve: https://app.circleci.com/pipelines/gh/stitchdata/deploy-taps/653/workflows/694bc4e0-02f9-4966-bb7c-05a1a417375c/jobs/648?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
