### PR TITLE
Bump singer-clojure to fix cve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.8.1
   * Update singer-clojure to 1.2.1 (log4j CVE fixes) [#94](https://github.com/singer-io/tap-mssql/pull/94)
   * Bump org.clojure/clojure to 1.11.2 [#95](https://github.com/singer-io/tap-mssql/pull/95)
+  * Update singer-clojure to 1.2.2 (clojure CVE fixes) [#96](https://github.com/singer-io/tap-mssql/pull/96)
 
 ## 1.8.0
   * Retry logic for the Deadlock error [#91](https://github.com/singer-io/tap-mssql/pull/91)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
 ## 1.8.1
-  * Update singer-clojure to 1.2.1 (log4j CVE fixes) [#94](https://github.com/singer-io/tap-mssql/pull/94)
-  * Bump org.clojure/clojure to 1.11.2 [#95](https://github.com/singer-io/tap-mssql/pull/95)
   * Update singer-clojure to 1.2.2 (clojure CVE fixes) [#96](https://github.com/singer-io/tap-mssql/pull/96)
 
 ## 1.8.0

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [com.microsoft.sqlserver/mssql-jdbc "7.2.1.jre8"]
 
                  ;; singer-clojure
-                 [singer-clojure "1.2.1"]
+                 [singer-clojure "1.2.2"]
 
                  ;; repl
                  [nrepl "0.6.0"]              ;; For Lein 2.9.X


### PR DESCRIPTION
# Description of change
Bump singer-clojure to 1.2.2 to fix cve 
# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
